### PR TITLE
update admin races list

### DIFF
--- a/app/controllers/admin/races_controller.rb
+++ b/app/controllers/admin/races_controller.rb
@@ -2,7 +2,7 @@ class Admin::RacesController < Admin::BaseController
   before_action :set_race, only: [:edit, :update, :show, :destroy]
 
   def index
-    @races = Race.includes(:event).order("events.name ASC")
+    @races = Race.by_starts_at
   end
 
   def show

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,7 +1,6 @@
 class Race < ApplicationRecord
   extend FriendlyId
   friendly_id :generate_slug, use: :slugged
-  default_scope { order(name: :asc) }
 
   belongs_to :event
   has_one :location, through: :event


### PR DESCRIPTION
 - removes the default scope
 - removes the unnecessary `includes` call
 - sets the expected order