### PR TITLE
apply logic to credentials hash setting

### DIFF
--- a/app/controllers/admin/races_controller.rb
+++ b/app/controllers/admin/races_controller.rb
@@ -2,7 +2,7 @@ class Admin::RacesController < Admin::BaseController
   before_action :set_race, only: [:edit, :update, :show, :destroy]
 
   def index
-    @races = Race.includes(:event).order("events.name ASC")
+    @races = Race.by_starts_at
   end
 
   def show

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,7 +1,6 @@
 class Race < ApplicationRecord
   extend FriendlyId
   friendly_id :generate_slug, use: :slugged
-  default_scope { order(name: :asc) }
 
   belongs_to :event
   has_one :location, through: :event

--- a/config/initializers/stripe.rb
+++ b/config/initializers/stripe.rb
@@ -1,6 +1,10 @@
 require "stripe"
 
-credentials_hash = Rails.application.credentials.send(Rails.env.to_sym)
+if Rails.application.credentials.present?
+  credentials_hash = Rails.application.credentials.send(Rails.env.to_sym)
+else
+  credentials_hash = {}
+end
 
 Rails.configuration.stripe = {
   publishable_key: credentials_hash.fetch(:stripe_publishable_key, "test"),


### PR DESCRIPTION
This does not feel like the best, most technically correct approach to solving this problem. Ultimately, `Rails.application.credentials` needs to be available in all environs. This is a bandaid until I can get a better grasp on credentials in rails 5.2