### PR TITLE
adds a page for each individual team member

### DIFF
--- a/app/controllers/admin/team_members_controller.rb
+++ b/app/controllers/admin/team_members_controller.rb
@@ -49,7 +49,7 @@ class Admin::TeamMembersController < Admin::BaseController
   private
 
   def set_team_member
-    @team_member = TeamMember.find(params[:id])
+    @team_member = TeamMember.friendly.find(params[:id])
   end
 
   def team_member_params

--- a/app/controllers/team_members_controller.rb
+++ b/app/controllers/team_members_controller.rb
@@ -1,11 +1,17 @@
 class TeamMembersController < ApplicationController
   def index
-    @team_members = TeamMember.order(name: :asc)
+    @team_members = fetch_team_members
     @leaders = @team_members.select { |member| member.is_leader == true }
     @blazers = @team_members.select { |member| member.is_leader == false }
   end
 
   def show
     @team_member = TeamMember.friendly.find(params[:id]).decorate
+  end
+
+  private
+
+  def fetch_team_members
+    TeamMember.includes(:profile_image_attachment).order(name: :asc)
   end
 end

--- a/app/controllers/team_members_controller.rb
+++ b/app/controllers/team_members_controller.rb
@@ -1,8 +1,11 @@
 class TeamMembersController < ApplicationController
-
   def index
     @team_members = TeamMember.order(name: :asc)
     @leaders = @team_members.select { |member| member.is_leader == true }
     @blazers = @team_members.select { |member| member.is_leader == false }
+  end
+
+  def show
+    @team_member = TeamMember.friendly.find(params[:id]).decorate
   end
 end

--- a/app/decorators/team_member_decorator.rb
+++ b/app/decorators/team_member_decorator.rb
@@ -6,4 +6,12 @@ class TeamMemberDecorator < ApplicationDecorator
       helpers.asset_path("logo-no-text")
     end
   end
+
+  def default_cover_photo_url
+    if cover_image.attached?
+      helpers.url_for(cover_image)
+    else
+      helpers.asset_path("logo-no-text")
+    end
+  end
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -3,4 +3,10 @@ class TeamMember < ApplicationRecord
 
   has_one_attached :profile_image
   has_one_attached :cover_image
+
+  extend FriendlyId
+  friendly_id :name, use: :slugged
+  def should_generate_new_friendly_id?
+    slug.blank? || name_changed?
+  end
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -9,4 +9,8 @@ class TeamMember < ApplicationRecord
   def should_generate_new_friendly_id?
     slug.blank? || name_changed?
   end
+
+  def social?
+    instagram_link.present? || strava_link.present?
+  end
 end

--- a/app/views/admin/team_members/_form.html.haml
+++ b/app/views/admin/team_members/_form.html.haml
@@ -3,45 +3,76 @@
   = f.error_notification
   - if f.object.errors[:base].present?
     = f.error_notification message: f.object.errors[:base].to_sentence
+  .row
+    .col-12
+      .form-inputs
+        %fieldset
+          %legend Basics
+          = f.input :name, required: true
+          = f.input :slug, hint: "Auto-generated", input_html: { disabled: true }
+          = f.input :title
+          = f.input :is_leader
+          = f.input :strava_link
+          = f.input :instagram_link
+          = f.input :bio_html,
+            as: :text,
+            input_html: { class: "textarea-autosize" },
+            required: true
+          = f.input :best_advice,
+            as: :text,
+            input_html: { class: "textarea-autosize" },
+            required: true
+  .row
+    .col-6
+      %fieldset
+        %legend Profile Image
+        %strong.text-danger MUST BE IN PORTRAIT ORIENTATION OR ELSE IT WILL LOOK BAD
+        .form-row
+          .col-sm-12.col-md-4
+            = f.file_field :profile_image,
+              direct_upload: true,
+              class: "custom-input-file",
+              type: 'file',
+              "data-multiple-caption" => "{count} files selected"
+            = f.label :profile_image do
+              %i.fa.fa-upload
+              %span Select Profile Image *
+              %small.text-muted Please select exatly one
+            - if f.object.profile_image.attached?
+              .attachment-wrapper{id: "attachment-wrapper-#{f.object.profile_image.id}"}
+                = image_tag f.object.profile_image,
+                  class: "img img-fluid img-thumbnail"
+                = link_to attachment_path(id: f.object.profile_image.id),
+                  method: :delete,
+                  remote: true,
+                  class: "text-danger" do
+                  %i.fa.fa-times
+    .col-6
+      %fieldset
+        %legend Cover Image
+        %strong.text-danger MUST BE IN LANDSCAPE ORIENTATION OR ELSE IT WILL LOOK BAD
+        .form-row
+          .col-sm-12.col-md-4
+            = f.file_field :cover_image,
+              direct_upload: true,
+              class: "custom-input-file",
+              type: 'file',
+              "data-multiple-caption" => "{count} files selected"
+            = f.label :cover_image do
+              %i.fa.fa-upload
+              %span Select Profile Image *
+              %small.text-muted Please select exatly one
+            - if f.object.cover_image.attached?
+              .attachment-wrapper{id: "attachment-wrapper-#{f.object.cover_image.id}"}
+                = image_tag f.object.cover_image,
+                  class: "img img-fluid img-thumbnail"
+                = link_to attachment_path(id: f.object.cover_image.id),
+                  method: :delete,
+                  remote: true,
+                  class: "text-danger" do
+                  %i.fa.fa-times
 
-  .form-inputs
-    %fieldset
-      %legend Basics
-      = f.input :name, required: true
-      = f.input :title
-      = f.input :is_leader
-      = f.input :strava_link
-      = f.input :instagram_link
-      = f.input :bio_html,
-        as: :text,
-        input_html: { class: "textarea-autosize" },
-        required: true
-      = f.input :best_advice,
-        as: :text,
-        input_html: { class: "textarea-autosize" },
-        required: true
-    %fieldset
-      %legend Profile Image
-      %strong.text-danger MUST BE IN PORTRAIT ORIENTATION OR ELSE IT WILL LOOK BAD
-      .form-row
-        .col-sm-12.col-md-4
-          = f.file_field :profile_image,
-            direct_upload: true,
-            class: "custom-input-file",
-            type: 'file',
-            "data-multiple-caption" => "{count} files selected"
-          = f.label :profile_image do
-            %i.fa.fa-upload
-            %span Select Profile Image *
-            %small.text-muted Please select exatly one
-          - if f.object.profile_image.attached?
-            .attachment-wrapper{id: "attachment-wrapper-#{f.object.profile_image.id}"}
-              = image_tag f.object.profile_image,
-                class: "img img-fluid img-thumbnail"
-              = link_to attachment_path(id: f.object.profile_image.id),
-                method: :delete,
-                remote: true,
-                class: "text-danger" do
-                %i.fa.fa-times
-  .form-actions.float-right
-    = f.button :submit, class: "btn btn-success btn-sm"
+  .row
+    .col-12
+      .form-actions.float-right
+        = f.button :submit, class: "btn btn-success btn-sm"

--- a/app/views/team_members/_leader.html.haml
+++ b/app/views/team_members/_leader.html.haml
@@ -4,3 +4,10 @@
     %h4.card-title.text-white= team_member.name
     %hr.bg-white
     %h6.card-title.text-white= team_member.title
+    - if team_member.best_advice?
+      %q.card-text.text-white= team_member.best_advice
+    %br
+  .card-footer.bg-tertiary
+    %div.text-center
+      = link_to team_member_path(team_member), class: "btn btn-md border-white text-white bg-dark" do
+        PROFILE

--- a/app/views/team_members/_team_member.html.haml
+++ b/app/views/team_members/_team_member.html.haml
@@ -15,3 +15,7 @@
       - if team_member.instagram_link.present?
         %a{href: team_member.instagram_link, target: "_blank"}
           %i.fab.fa-instagram.fa-2x.text-white
+      %br
+      %div.m-3
+        = link_to team_member_path(team_member), class: "btn btn-md border-white text-white bg-dark" do
+          Profile

--- a/app/views/team_members/index.html.haml
+++ b/app/views/team_members/index.html.haml
@@ -11,10 +11,10 @@
 
 %section
   .container.d-flex.align-items-center.mt-5.mb-5
-    %h1.text-tertiary
+    %h2.text-tertiary
       The people who run with Spectrum not only share the vision and values of our community, they embody it.
   .container.d-flex.align-items-center.mb-5
-    %h2.text-tertiary
+    %h4.text-tertiary
       We are ambassadors to the sport. We are mentors. We are competitors. We are family. Come run with us!
 
 %section.bg-tertiary.pt-2.pb-2

--- a/app/views/team_members/show.html.haml
+++ b/app/views/team_members/show.html.haml
@@ -1,0 +1,34 @@
+%section.spotlight.parallaxy.bg-cover.bg-size--cover{"data-spotlight" => "fullscreen", style: "background-image: url(#{@team_member.default_cover_photo_url})"}
+  %span.mask.bg-dark.alpha-7
+  .spotlight-holder.py-lg.pt-lg-xl
+    .container.d-flex.align-items-center.no-padding
+      .col
+        .row.cols-xs-space.text-center.text-md-left.justify-content-center
+          .col-lg-10
+            .text-center.mt-5
+              %h1.heading.h1.text-white= @team_member.name
+              - if @team_member.is_leader?
+                %p.lead.lh-180.text-white.mt-3= @team_member.title
+
+%section.slice
+  .container
+    .row
+      .col-12
+        = @team_member.bio_html.html_safe
+
+- if @team_member.social?
+  %section.slice
+    .container
+      .row
+        .col-12
+          .text-center
+            %h4.h4 Keep up with #{@team_member.name}!
+      .row
+        .col-12
+          .text-center
+            - if @team_member.strava_link.present?
+              %a{href: @team_member.strava_link, target: "_blank"}
+                %i.fab.fa-strava.fa-4x.text-warning.mr-3
+            - if @team_member.instagram_link.present?
+              %a{href: @team_member.instagram_link, target: "_blank"}
+                %i.fab.fa-instagram.fa-4x.text-tertiary

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -28,7 +28,7 @@ Rails.application.routes.draw do
   end
   resources :sponsors, only: [:index]
   resources :series, only: [:show]
-  resources :team_members, path: "team", only: [:index]
+  resources :team_members, path: "team", only: [:index, :show]
 
   namespace :members do
     resource :profile, controller: "profile", only: [:show, :edit, :update]

--- a/db/migrate/20191210171651_add_slug_to_team_members.rb
+++ b/db/migrate/20191210171651_add_slug_to_team_members.rb
@@ -1,0 +1,7 @@
+class AddSlugToTeamMembers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :team_members, :slug, :string
+    add_index :team_members, :slug, unique: true
+    TeamMember.find_each(&:save!) # builds the initial slug
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_11_30_214356) do
+ActiveRecord::Schema.define(version: 2019_12_10_171651) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -303,6 +303,8 @@ ActiveRecord::Schema.define(version: 2019_11_30_214356) do
     t.boolean "is_leader", default: false
     t.string "title"
     t.string "best_advice"
+    t.string "slug"
+    t.index ["slug"], name: "index_team_members_on_slug", unique: true
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
Addresses #87 #88 

#### This PR introduces a new page for to show each team member individually.

It can be accessed by going to /team/#{team_member.name}

Here are the mockups:

https://spectrumtrail.invisionapp.com/overview/Race-Team-Pages-ck3yuuocs0pvv017ok220s1po/screens?v=Kudu%2BqqasENdl6DEeaU%2FCA%3D%3D&linkshare=urlcopied

Digressions from the mockups:
 - use a white background
 - move title text to image cover
 - add 'profile' button to team member cards

#### How to review this PR:

 - [ ] Pull down this branch
 - [ ] Run `rake db:migrate`
 - [ ] Restart `rails s`
 - [ ] Fill in necessary data for each team member
 - [ ] Navigate to each team member's page