### PR TITLE
feature: add the ability to associate a registration to a user

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -27,7 +27,7 @@ class Participant < ApplicationRecord
   validates :emergency_contact_phone, presence: true, if: :validate_waiver?
   validates :accepts_waiver, acceptance: true, if: :validate_waiver?
 
-  delegate :archived?, :step_to_validate, to: :registration
+  delegate :archived?, :step_to_validate, :user, to: :registration
 
   scope :with_payment, -> { joins(:payment) }
   scope :created_after, ->(time) { after(time) }

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -9,6 +9,7 @@ class Registration < ApplicationRecord
 
   belongs_to :event
   belongs_to :discount_code, counter_cache: true, optional: true
+  belongs_to :user, optional: true
   has_one :location, through: :event
   has_one :participant, dependent: :destroy
   has_one :race, through: :participant

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,7 @@
 class User < ApplicationRecord
   has_many :visits, class_name: "Ahoy::Visit"
+  has_many :registrations
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable,
          :confirmable, :lockable, :trackable

--- a/app/views/registrations/_form.html.haml
+++ b/app/views/registrations/_form.html.haml
@@ -2,6 +2,7 @@
 = simple_form_for([@event, @registration], validate: true) do |f|
   = f.input :started_at, as: :hidden, input_html: { value: @registration.started_at }
   = f.input :step_to_validate, as: :hidden, input_html: { value: "start" }
+  = f.input :user_id, as: :hidden, input_html: { value: current_user.try(:id) }
   = f.error_notification
   - if f.object.errors[:base].present?
     = f.error_notification message: f.object.errors[:base].to_sentence

--- a/db/migrate/20191215184705_add_user_to_registrations.rb
+++ b/db/migrate/20191215184705_add_user_to_registrations.rb
@@ -1,0 +1,5 @@
+class AddUserToRegistrations < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :registrations, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_10_171651) do
+ActiveRecord::Schema.define(version: 2019_12_15_184705) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -268,9 +268,11 @@ ActiveRecord::Schema.define(version: 2019_12_10_171651) do
     t.string "admin_notes"
     t.bigint "ahoy_visit_id"
     t.datetime "archived_at"
+    t.bigint "user_id"
     t.index ["discount_code_id"], name: "index_registrations_on_discount_code_id"
     t.index ["event_id"], name: "index_registrations_on_event_id"
     t.index ["token"], name: "index_registrations_on_token", unique: true
+    t.index ["user_id"], name: "index_registrations_on_user_id"
   end
 
   create_table "series", force: :cascade do |t|
@@ -355,4 +357,5 @@ ActiveRecord::Schema.define(version: 2019_12_10_171651) do
   add_foreign_key "refunds", "payments"
   add_foreign_key "registrations", "discount_codes"
   add_foreign_key "registrations", "events"
+  add_foreign_key "registrations", "users"
 end


### PR DESCRIPTION
Registrations, in this system, serve as a data container pertinent to the individual registrant. Given the importance of the fact that each individual registrant must **SIGN THEIR OWN WAIVER**, we can use the registration class to be the association with the individual user (member, in this parlance), in pursuit of a user profile experience.

The current registration experience **DOES NOT** support the creation of accounts. This PR introduces the bare minimum of the functionality needed to support that.

To test:

 - [x] Pull down this branch
 - [x] Run migrations 
 - [x] Sign in as an admin
 - [x] Register for an available race

^ everything should work, and the user_id value should be set on your registration