### PR TITLE
chore: update race team banner text

### DIFF
--- a/app/views/team_members/index.html.haml
+++ b/app/views/team_members/index.html.haml
@@ -6,8 +6,8 @@
         .row.cols-xs-space.text-center.text-md-left.justify-content-center
           .col-lg-10
             .text-center.mt-5
-              %h1.display-1.text-white
-                Our Team
+              %h3.display-3.text-white
+                Meet The Spectrum Race Team
 
 %section
   .container.d-flex.align-items-center.mt-5.mb-5


### PR DESCRIPTION
I updated the the race team banner text from Our Team to Meet The Spectrum Race Team
Before
<img width="1435" alt="Screen Shot 2019-12-18 at 12 15 55 PM" src="https://user-images.githubusercontent.com/44638093/71112001-37005f80-2190-11ea-8508-648b1152ea4f.png">
After
![Uploading Screen Shot 2019-12-18 at 12.15.49 PM.png…]()
Because I think the new text sounds better.

