### PR TITLE
feature: adds page just for results to the header

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -21,6 +21,9 @@ class StaticPagesController < ApplicationController
     redirect_to("https://store.spectrumtrailracing.com")
   end
 
+  def results_path
+  end
+
   def terms
   end
 

--- a/app/views/navigation/_header_links.html.haml
+++ b/app/views/navigation/_header_links.html.haml
@@ -6,6 +6,8 @@
       - @menu_events.each do |event|
         %a.dropdown-item{href: event_path(event)}= event.name
   %li.nav-item
+    %a.nav-link{href: results_path} Results
+  %li.nav-item
     %a.nav-link{href: "https://store.spectrumtrailracing.com/store", target: "_blank"} Store
   %li.nav-item
     %a.nav-link{href: "https://www.roguerunning.com/trail", target: "_blank"} Training

--- a/app/views/static_pages/results.html.haml
+++ b/app/views/static_pages/results.html.haml
@@ -1,0 +1,7 @@
+%section.slice.slice-xl
+  .container
+    .row
+      .col-12
+        %h1 Results
+    .row.mt-2
+      %iframe#raceroster{:src => "https://timer.raceroster.com/Calendars/L6crPG2qbgq2eCkzWNVMdUF", :style => "border:none; height:700px; width:100%"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
   match '/privacy' => "static_pages#privacy", via: [:get]
   match 'policies' => "static_pages#policies", via: [:get]
   match '/no-script-warning' => 'static_pages#no_script_warning', via: [:get]
+  match '/results' => 'static_pages#results', via: [:get]
 
   resources :attachments, only: [:destroy]
   resources :discount_codes do


### PR DESCRIPTION
This is a static page with a dynamic embed code from RaceRoster

It can be seen by visiting /results

![image](https://user-images.githubusercontent.com/3529146/71116542-94e17700-2191-11ea-862c-9ec9af192dd9.png)
