### PR TITLE
adds ecommerce tracking abilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'scout_apm'
 # Built-in Analytics
 gem 'ahoy_matey'
 
+# Ecommerce Tracking
+gem 'rack-tracker'
+
 group :development, :test do
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
   gem 'dotenv-rails', groups: [:development, :test]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -264,6 +264,10 @@ GEM
       rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
+    rack-tracker (1.12.0)
+      activesupport (>= 3.0)
+      rack (>= 1.4)
+      tilt (>= 1.4)
     rails (5.2.2)
       actioncable (= 5.2.2)
       actionmailer (= 5.2.2)
@@ -446,6 +450,7 @@ DEPENDENCIES
   pg (>= 0.18, < 2.0)
   premailer-rails
   puma (~> 4.3)
+  rack-tracker
   rails (~> 5.2.2)
   ransack
   redis (~> 4.0)

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -16,8 +16,6 @@
     %script{:src => "https://cdnjs.cloudflare.com/ajax/libs/gsap/2.0.2/TweenMax.min.js"}
     - if Rails.env.production?
       = render partial: "shared/drift_script"
-    - if Rails.env.production?
-      = render partial: "shared/google_analytics_script"
   %body{class: "application #{controller_name}", id: "#{controller_name}_#{action_name}"}
     = render "navigation/dark_header"
     %main.main

--- a/app/views/layouts/devise.html.haml
+++ b/app/views/layouts/devise.html.haml
@@ -10,8 +10,6 @@
     = Gon::Base.render_data
     - if Rails.env.production?
       = render partial: "shared/drift_script"
-    - if Rails.env.production?
-      = render partial: "shared/google_analytics_script"
   %body{class: "application #{controller_name}", id: "#{controller_name}_#{action_name}"}
     %main.main.with-topo-background{style: "min-height: 100vh; background-color: linen"}
       = render partial: 'flash_messages', flash: flash

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,10 @@ module Spectrum
       generator.test_framework  false
       generator.factory_bot suffix: "factory"
     end
+
+    config.middleware.use(Rack::Tracker) do
+      handler :google_analytics, { tracker: ENV['GOOGLE_ANALYTICS_ID'], ecommerce: true, position: :body }
+      handler :facebook_pixel, { id: ENV['PIXEL_ID'], position: :body }
+    end
   end
 end


### PR DESCRIPTION
To better understand our marketing efforts towards growing our trail racing community, we want to embed tracking codes that identify user sources, via Google and Facebook.

We will use `rack-tracker` to do this. Important: THIS IMPLEMENTATION RESPECTS USER `do_not_track` HTTP HEADERS, as well as ad-blockers, and other user privacy measures.