### PR TITLE
adds a backend interface to manage home page images

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "puma", "~> 4.3"
 gem "devise"
 gem "barnes"
 gem "airbrake", '~> 9.5'
+gem 'ranked-model'
 
 # Asset Storage
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -293,6 +293,8 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.3)
+    ranked-model (0.4.4)
+      activerecord (>= 4.1.16)
     ransack (2.3.0)
       actionpack (>= 5.0)
       activerecord (>= 5.0)
@@ -452,6 +454,7 @@ DEPENDENCIES
   puma (~> 4.3)
   rack-tracker
   rails (~> 5.2.2)
+  ranked-model
   ransack
   redis (~> 4.0)
   rspec

--- a/app/controllers/admin/home_page_images_controller.rb
+++ b/app/controllers/admin/home_page_images_controller.rb
@@ -1,0 +1,38 @@
+class Admin::HomePageImagesController < Admin::BaseController
+  def index
+    @home_page_images = HomePageImage.rank(:display_order).all
+  end
+
+  def new
+    @home_page_image = HomePageImage.new
+  end
+
+  def create
+    @home_page_image = HomePageImage.new(home_page_image_params)
+
+    if @home_page_image.save
+      flash[:success] = "Home Page Image successfully created."
+      redirect_to admin_home_page_images_path
+    else
+      render :new
+    end
+  end
+
+  def destroy
+    @home_page_image = HomePageImage.find(params[:id])
+
+    if @home_page_image.destroy
+      flash[:success] = "Successfully removed Home Page Image"
+      redirect_to admin_home_page_images_path
+    else
+      flash[:error] = "Could not destroy this Home Page Image"
+      redirect_to admin_home_page_images_path
+    end
+  end
+
+  private
+
+  def home_page_image_params
+    params.require(:home_page_image).permit!
+  end
+end

--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -9,9 +9,17 @@ class StaticPagesController < ApplicationController
   end
 
   def home
-    @events = Event.includes(:location, :cover_photo_attachment).is_active.by_starts_at.decorate
+    @events = Event.includes(:location, :cover_photo_attachment).
+                    is_active.
+                    by_starts_at.
+                    decorate
+
+
+    @home_page_images = HomePageImage.includes(:image_attachment).
+                                      not_hidden.
+                                      rank(:display_order)
+
     @sponsors = Sponsor.includes(:logo_attachment).order(:name).decorate
-    @promo_photos = @events.map { |event| event.promo_photos.first(4) }.flatten!
   end
 
   def privacy

--- a/app/models/home_page_image.rb
+++ b/app/models/home_page_image.rb
@@ -1,0 +1,8 @@
+class HomePageImage < ApplicationRecord
+  include RankedModel
+  ranks :display_order
+
+  has_one_attached :image
+
+  scope :not_hidden, -> { where(hidden: false) }
+end

--- a/app/views/admin/home_page_images/index.html.haml
+++ b/app/views/admin/home_page_images/index.html.haml
@@ -1,0 +1,22 @@
+= content_for :admin_area_title do
+  Home Page Images
+.row
+  .col-12
+    - @home_page_images.in_groups_of(4, false).each do |home_page_image_group|
+      .row
+        - home_page_image_group.each do |home_page_image|
+          .col-sm-12.col-md-3
+            = image_tag home_page_image.image, class: "img-fluid img-thumbnail"
+            .float-left
+              %span.text-muted= home_page_image.display_order
+            .float-right
+              = link_to admin_home_page_image_path(home_page_image), method: :delete, data: { confirm: "Are you sure?" } do
+                %i.fa.fa-times.text-danger
+                Destroy
+%hr
+.row
+  .col-12
+    .float-right
+      = link_to "Add New Home Page Image",
+        new_admin_home_page_image_path,
+        class: "btn btn-sm btn-success"

--- a/app/views/admin/home_page_images/new.html.haml
+++ b/app/views/admin/home_page_images/new.html.haml
@@ -1,0 +1,48 @@
+-# frozen_string_literal: true
+.row
+  .col
+    %h1 New Home Page Image
+    %p Home page images are loaded in a responsive, browsable photo gallery.
+
+.row
+  .col
+    = simple_form_for([:admin, @home_page_image], multipart: true) do |f|
+      = f.error_notification
+      - if f.object.errors[:base].present?
+        = f.error_notification message: f.object.errors[:base].to_sentence
+      .form-inputs
+        %fieldset
+          = f.input :short_name
+          = f.input :display_order,
+            hint: "Guides display order. Responsive styling may override."
+          = f.input :hidden
+        %fieldset
+          %legend Image
+          %strong.text-danger It is extremely important that you OPTIMIZE the image BEFORE uploading it for the sake of page load speed.
+          %p Landscape images will look the best, generally speaking, especially on mobile.
+          .form-row
+            = f.file_field :image,
+              direct_upload: true,
+              class: "custom-input-file",
+              type: 'file',
+              "data-multiple-caption" => "{count} files selected"
+            = f.label :image do
+              %i.fa.fa-upload
+              %span Select Web Optimized Image
+            - if f.object.image.attached?
+              .attachment-wrapper{id: "attachment-wrapper-#{f.object.image.id}"}
+                = image_tag f.object.image,
+                  class: "img img-fluid img-thumbnail"
+                = link_to attachment_path(id: f.object.image.id), method: :delete, remote: true, class: "text-danger" do
+                  %i.fa.fa-times
+
+      %br
+      .form-actions
+        = link_to admin_home_page_images_path,
+          class: "btn btn-md btn-outline-secondary mr-2",
+          data: { confirm: "Careful! You will lose any progress you made on this form."} do
+          %i.fas.fa-arrow-left
+          Go Back
+        = f.button :submit,
+          class: "btn btn-md btn-outline-success",
+          data: { disable_with: "Submitting..." }

--- a/app/views/admin/navigation/_sidebar.html.haml
+++ b/app/views/admin/navigation/_sidebar.html.haml
@@ -50,3 +50,5 @@
         Public Pages
       %li.navigation-item
         %a.navigation-link{href: root_path} Home
+      %li.navigation-item
+        %a.navigation-link{href: admin_home_page_images_path} Home Page Images

--- a/app/views/shared/sections/_promo_photos_grid.html.haml
+++ b/app/views/shared/sections/_promo_photos_grid.html.haml
@@ -17,8 +17,9 @@
 
     .row
       .card-columns
-        - @promo_photos.each do |promo_photo|
-          - cache promo_photo do
+        - @home_page_images.each do |home_page_image|
+          - cache home_page_image do
             .card
-              %a{"data-gallery" => "example-gallery", "data-toggle" => "lightbox", href: url_for(promo_photo)}
-                = image_tag promo_photo, class: "img img-fluid rounded"
+              %a{"data-gallery" => "example-gallery", "data-toggle" => "lightbox", href: url_for(home_page_image.image)}
+                = image_tag home_page_image.image,
+                  class: "img img-fluid rounded"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -77,5 +77,6 @@ Rails.application.routes.draw do
     resources :team_members
     resource :profile, controller: "profile", only: [:show, :edit, :update]
     resources :users
+    resources :home_page_images, only: [:index, :new, :create, :destroy]
   end
 end

--- a/db/migrate/20191224162923_create_home_page_images.rb
+++ b/db/migrate/20191224162923_create_home_page_images.rb
@@ -1,0 +1,11 @@
+class CreateHomePageImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :home_page_images do |t|
+      t.string :short_name
+      t.integer :display_order
+      t.boolean :hidden, default: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_20_201348) do
+ActiveRecord::Schema.define(version: 2019_12_24_162923) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -152,6 +152,14 @@ ActiveRecord::Schema.define(version: 2019_12_20_201348) do
     t.index ["slug", "sluggable_type", "scope"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type_and_scope", unique: true
     t.index ["slug", "sluggable_type"], name: "index_friendly_id_slugs_on_slug_and_sluggable_type"
     t.index ["sluggable_type", "sluggable_id"], name: "index_friendly_id_slugs_on_sluggable_type_and_sluggable_id"
+  end
+
+  create_table "home_page_images", force: :cascade do |t|
+    t.string "short_name"
+    t.integer "display_order"
+    t.boolean "hidden", default: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "locations", force: :cascade do |t|


### PR DESCRIPTION
Bonus feature!

Adds a data table specifically to manage the home page image grid.

Why: 

 - It's easier for admins to manage
 - It's easier to tune for page load performance

**Note:** this PR only covers the backend changes. A subsequent PR will deal with the front end changes, to be merged _after_ business admins have a chance to select their home page images.