### PR TITLE
feature: display HomePageImages in a masonry section

### DIFF
--- a/app/controllers/static_pages_controller.rb
+++ b/app/controllers/static_pages_controller.rb
@@ -9,9 +9,17 @@ class StaticPagesController < ApplicationController
   end
 
   def home
-    @events = Event.includes(:location, :cover_photo_attachment).is_active.by_starts_at.decorate
+    @events = Event.includes(:location, :cover_photo_attachment).
+                    is_active.
+                    by_starts_at.
+                    decorate
+
+
+    @home_page_images = HomePageImage.includes(:image_attachment).
+                                      not_hidden.
+                                      rank(:display_order)
+
     @sponsors = Sponsor.includes(:logo_attachment).order(:name).decorate
-    @promo_photos = @events.map { |event| event.promo_photos.first(4) }.flatten!
   end
 
   def privacy

--- a/app/views/shared/sections/_promo_photos_grid.html.haml
+++ b/app/views/shared/sections/_promo_photos_grid.html.haml
@@ -17,8 +17,9 @@
 
     .row
       .card-columns
-        - @promo_photos.each do |promo_photo|
-          - cache promo_photo do
+        - @home_page_images.each do |home_page_image|
+          - cache home_page_image do
             .card
-              %a{"data-gallery" => "example-gallery", "data-toggle" => "lightbox", href: url_for(promo_photo)}
-                = image_tag promo_photo, class: "img img-fluid rounded"
+              %a{"data-gallery" => "example-gallery", "data-toggle" => "lightbox", href: url_for(home_page_image.image)}
+                = image_tag home_page_image.image,
+                  class: "img img-fluid rounded"


### PR DESCRIPTION
This replaces the current image grid under the video on the main page. No differences to speak of (so no image to paste here).