### PR TITLE
feature: add ability to store results link

### DIFF
--- a/app/views/admin/races/_form.html.haml
+++ b/app/views/admin/races/_form.html.haml
@@ -22,6 +22,8 @@
       = f.input :price_in_cents
       = f.input :short_description,
         hint: "What is special about this race? Elevator pitch."
+      = f.input :external_results_link,
+        hint: "Where can participants find their results for this race?"
     %fieldset
       %legend Registration Settings
       = f.input :is_active,

--- a/db/migrate/20200217164731_add_external_results_link_to_races.rb
+++ b/db/migrate/20200217164731_add_external_results_link_to_races.rb
@@ -1,0 +1,5 @@
+class AddExternalResultsLinkToRaces < ActiveRecord::Migration[5.2]
+  def change
+    add_column :races, :external_results_link, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_12_24_162923) do
+ActiveRecord::Schema.define(version: 2020_02_17_164731) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -239,6 +239,7 @@ ActiveRecord::Schema.define(version: 2019_12_24_162923) do
     t.integer "participants_count", default: 0
     t.integer "participants_cap", default: 500
     t.boolean "requires_team_name", default: false
+    t.string "external_results_link"
     t.index ["event_id"], name: "index_races_on_event_id"
     t.index ["slug"], name: "index_races_on_slug", unique: true
   end


### PR DESCRIPTION
This is going to be important for the new Members feature, and super useful elsewhere as well.

Admins can enter this information on the `/races/edit` view