### PR TITLE
adjusts is_full? logic

### DIFF
--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -48,7 +48,7 @@ class Race < ApplicationRecord
   end
 
   def is_full?
-    paid_participants_count >= participants_cap
+    participants.for_start_list >= participants_cap
   end
 
   def is_registerable?(time)

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -48,7 +48,7 @@ class Race < ApplicationRecord
   end
 
   def is_full?
-    participants.for_start_list >= participants_cap
+    participants.for_start_list.size >= participants_cap
   end
 
   def is_registerable?(time)


### PR DESCRIPTION
Resolves #158, if necessary.

Implications: if race is capped at 130, then admins raise cap to 150, then 150 registrations met, then 1 person drops out, race will show as available for registration. This makes sense mathematically; but, does it make sense in business practice? Need confirmation from business.