### PR TITLE
Add redcarpet Markdown processor

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gem "barnes"
 gem "airbrake", '~> 9.5'
 gem 'ranked-model'
 
+# Parsing
+gem "redcarpet", "~> 3.5"
+
 # Asset Storage
 gem "aws-sdk-s3", require: false
 gem 'mini_magick', '~> 4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -305,6 +305,7 @@ GEM
     rb-inotify (0.10.0)
       ffi (~> 1.0)
     rbtree3 (0.5.0)
+    redcarpet (3.5.0)
     redis (4.1.0)
     regexp_parser (1.3.0)
     regexp_property_values (0.3.4)
@@ -456,6 +457,7 @@ DEPENDENCIES
   rails (~> 5.2.2)
   ranked-model
   ransack
+  redcarpet (~> 3.5)
   redis (~> 4.0)
   rspec
   rspec-rails (~> 3.8)
@@ -478,4 +480,4 @@ RUBY VERSION
    ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.6
+   1.17.3


### PR DESCRIPTION
This adds the redcarpet gem to allow use of Markdown for page content.