### PR TITLE
feature: covid operating procedures page

### DIFF
--- a/app/assets/markdowns/covid.md
+++ b/app/assets/markdowns/covid.md
@@ -1,0 +1,49 @@
+# How We Are Operating During COVID-19
+
+Please know that we value the safety of our community and are continuously
+working to balance your safety with our shared desire to foster community and
+competition within the trail running and racing community. Our starting point is
+to lean on local, state, and federal guidelines. We draw on the following
+principles to guide our operating procedures and decision-making processes.
+
+## CDC Guidelines
+
+A detailed description of the CDC’s COVID-19 Operating procedures for event organizers can be found here: [https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/considerations-for-events-gatherings.html](https://www.cdc.gov/coronavirus/2019-ncov/community/large-events/considerations-for-events-gatherings.html)
+
+The most important factors for us to consider are to:
+
+- Encourage race registrants to stay home if they are feeling even minorly ill or have recently been in contact with an infected person.
+- Facilitate and encourage proper hand hygiene and respiratory etiquette following CDC guidelines as outlined by the CDC at the link provided above.
+  - We will provide hand sanitizer
+  - If we have to provide portable toilets, we will provide hand sanitizer and a handwashing station
+- Encourage participants to practice social distancing by maintaining at least six feet of separation between themselves and any participant who is not a member of the immediate household
+- Require the use of masks when maintaining social distancing is not possible, including while running on trails.
+- If not already present, place signs in high trafficked areas reminding participants to practice social distancing and wear masks where social distancing is not practical or possible.
+- Limit the number of participants allowed in the restroom at any given time (we will follow park guidelines here) and ensure, through signage if applicable, that participants maintain six feet of separation while waiting in line.
+- We will avoid food service as a safety precaution to minimize the possible spread of the novel coronavirus.
+- At aid stations, only water will be provided using a touchless nozzle system.
+
+## Texas State Guidelines Beyond Federal CDC Guidelines
+
+Full details of state health guidelines for COVID-19 can be found here: [https://dshs.texas.gov/coronavirus/opentexas.aspx#outdoor](https://dshs.texas.gov/coronavirus/opentexas.aspx#outdoor)
+
+The key guideline we must accommodate is that “Individuals may not be in a group larger than 10 individuals.”
+
+- We will use staggered start times sending off groups of 8 athletes (plus 2 race directors) every 10 minutes.
+
+## County Guidelines Beyond State DHS Guidelines
+
+We will follow County guidelines specific to our various race locations if and when they are available.
+
+## Additional Considerations Specific to Race Events
+
+Race timing will follow one of two approaches:
+
+- Manual timing of participants that requires no exchange of timing chips
+- Distribution of clean timing chips that are deposited in a bucket of soap and water by the individual participants at the end of the race
+- Participants will be required to provide their own race food which they can place at the start-finish area (if they are running the 20 or 30 mile options).
+- “Drop bags” will be set in a designated drop bag area where space will be provided for racers to access their drop bags and carry them away to a safe distance for use during a race.
+
+## Specific Race Considerations
+
+Please check the web page of any race you are considering running in order to understand the location and event specifics of logistics like chip timing, drop bags, and start waves.

--- a/app/assets/stylesheets/_covid_procedures.scss
+++ b/app/assets/stylesheets/_covid_procedures.scss
@@ -1,0 +1,39 @@
+.covid-procedures-markdown h1 {
+  text-align: left;
+  color: #FFFFFF;
+  margin-top: $spacer * 3;
+}
+
+.covid-procedures-markdown h2 {
+  text-align: center;
+  color: #FFFFFF;
+  margin-top: $spacer * 3;
+}
+
+.covid-procedures-markdown p {
+  color: #FFFFFF;
+  font-size: $lead-font-size;
+  font-weight: $lead-font-weight;
+  line-height: 1.8;
+  margin-top: $spacer;
+}
+
+.covid-procedures-markdown li {
+  color: #FFFFFF;
+  font-size: $lead-font-size;
+  font-weight: $lead-font-weight;
+  line-height: 1.8;
+}
+
+.covid-procedures-markdown a:link {
+  color: #FFFFFF;
+  text-decoration: underline;
+}
+
+.covid-procedures-markdown a:visited {
+  color: #800080;
+}
+
+.covid-procedures-markdown a:hover {
+    color: #0000FF;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -84,4 +84,5 @@
 @import "animated_success_circle";
 @import "profile_card";
 @import "team";
-@import "newsletter_signup_form"
+@import "newsletter_signup_form";
+@import "covid_procedures";

--- a/app/helpers/markdown_helper.rb
+++ b/app/helpers/markdown_helper.rb
@@ -1,0 +1,18 @@
+module MarkdownHelper
+  def markdown(text)
+    options = []
+    Markdown.new(text, *options).to_html.html_safe
+  end
+
+  class MarkdownRender < Redcarpet::Render::HTML
+    def initialize(extensions = {})
+      super extensions.merge(link_attributes: { target: '_blank' })
+    end
+  end
+
+  def markdown_file(filename)
+    path = Rails.root.join('app', 'assets', 'markdowns', filename)
+    text = File.read(path)
+    Redcarpet::Markdown.new(MarkdownRender, fenced_code_blocks: true).render(text).html_safe
+  end
+end

--- a/app/views/navigation/_covid_banner.html.haml
+++ b/app/views/navigation/_covid_banner.html.haml
@@ -1,0 +1,7 @@
+%nav.navbar.navbar-expand-lg.bg-primary
+  .container.justify-content-center.p-2
+    %h5.m-0.text-white
+      %i.fas.fa-exclamation-circle
+      Visit our
+      %a.text-white{href: covid_path, :style => "text-decoration: underline;"} COVID-19 resources page
+      for current guidelines and race information.

--- a/app/views/navigation/_dark_header.html.haml
+++ b/app/views/navigation/_dark_header.html.haml
@@ -1,9 +1,12 @@
-%nav.navbar.navbar-expand-lg.navbar-dark.bg-tertiary.fixed-top
-  .container
-    %a.navbar-brand{href: root_path}
-      %img.img-fluid{src: asset_path("logo-no-text"), style: "max-width: 4rem;"}
-      %span.text-white Spectrum Trail Racing
-    %button.navbar-toggler{"aria-controls" => "navbar_main", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-action" => "offcanvas-open", "data-target" => "#navbar_main", :type => "button"}
-      %span.navbar-toggler-icon
-    #navbar_main.navbar-collapse.offcanvas-collapse
-      = render "navigation/header_links"
+.fixed-top
+  %nav.navbar.navbar-expand-lg.navbar-dark.bg-tertiary
+    .container
+      %a.navbar-brand{href: root_path}
+        %img.img-fluid{src: asset_path("logo-no-text"), style: "max-width: 4rem;"}
+        %span.text-white Spectrum Trail Racing
+      %button.navbar-toggler{"aria-controls" => "navbar_main", "aria-expanded" => "false", "aria-label" => "Toggle navigation", "data-action" => "offcanvas-open", "data-target" => "#navbar_main", :type => "button"}
+        %span.navbar-toggler-icon
+      #navbar_main.navbar-collapse.offcanvas-collapse
+        = render "navigation/header_links"
+  - if !current_page?(covid_path)
+    = render "navigation/covid_banner"

--- a/app/views/static_pages/covid_procedures.html.haml
+++ b/app/views/static_pages/covid_procedures.html.haml
@@ -1,0 +1,10 @@
+%section.parallaxy.bg-cover.bg-size--cover{:style => "background-image: url(#{asset_url('https://live.staticflickr.com/65535/50490421496_9680f9a248_b.jpg')})"}
+  %span.mask.bg-tertiary.alpha-7
+  .spotlight-holder.py-lg.pt-lg-xl
+    .container.d-flex.align-items-center.no-padding
+      .col
+        .row.cols-xs-space.align-items-center.text-md-left.justify-content-center
+          .col-lg-7
+            .mt-5
+              .covid-procedures-markdown
+                = markdown_file('covid.md')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   root to: "static_pages#home"
   match '/about' => "static_pages#about", via: [:get]
   match '/coaching' => "static_pages#coaching", via: [:get]
+  match '/covid' => "static_pages#covid_procedures", via: [:get]
   match '/danger' => "static_pages#danger", via: [:get]
   match '/home' => "static_pages#home", via: [:get]
   match '/store' => "static_pages#store", via: [:get]


### PR DESCRIPTION
Addresses #162. Adds a covid alert banner at the bottom of the header. The banner links to a landing page with current guidelines and race info. This should provide users with enough answers to their covid related questions to halt direct inquiries to admins.

Additionally includes:
-We are now able to pass an entire Markdown file to the redcarpet gem which can then be called from a template. Files must be placed in \app\assets\markdowns. This should save time and make adding page content more efficient.