### PR TITLE
feature: spe-15-analytics-dashboard

### DIFF
--- a/app/controllers/admin/analytics_dashboard_controller.rb
+++ b/app/controllers/admin/analytics_dashboard_controller.rb
@@ -1,0 +1,5 @@
+class Admin::AnalyticsDashboardController < Admin::BaseController
+  def show
+    @races = Race.includes(:event).active.upcoming.by_starts_at.decorate
+  end
+end

--- a/app/controllers/admin/file_imports_controller.rb
+++ b/app/controllers/admin/file_imports_controller.rb
@@ -6,7 +6,7 @@ class Admin::FileImportsController < Admin::BaseController
   def create
     @file_import = FileImport.new(file_import_params)
     if @file_import.save
-      redirect_to admin_dashboard_path, success: "File Import succeeded."
+      redirect_to admin_main_dashboard_path, success: "File Import succeeded."
     else
       render :new
     end

--- a/app/controllers/admin/main_dashboard_controller.rb
+++ b/app/controllers/admin/main_dashboard_controller.rb
@@ -1,4 +1,4 @@
-class Admin::DashboardController < Admin::BaseController
+class Admin::MainDashboardController < Admin::BaseController
   def show
     @races = Race.includes(:event).active.upcoming.by_starts_at.decorate
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,7 +8,7 @@ class ApplicationController < ActionController::Base
 
   def after_sign_in_path_for(resource)
     if current_user.is_admin?
-      admin_dashboard_path
+      admin_main_dashboard_path
     else
       members_profile_path
     end

--- a/app/views/admin/analytics_dashboard/show.html.haml
+++ b/app/views/admin/analytics_dashboard/show.html.haml
@@ -1,0 +1,2 @@
+= content_for :admin_area_title do
+  Analytics Dashboard

--- a/app/views/admin/main_dashboard/show.html.haml
+++ b/app/views/admin/main_dashboard/show.html.haml
@@ -1,5 +1,5 @@
 = content_for :admin_area_title do
-  Dashboard
+  Main Dashboard
 
 .row
   .col-6

--- a/app/views/admin/navigation/_header.html.haml
+++ b/app/views/admin/navigation/_header.html.haml
@@ -4,7 +4,7 @@
       %span.navbar-toggler-icon
         %i.fas.fa-bars.text-dark
   .header-brand.d-xl-none
-    %a{href: admin_dashboard_path}
+    %a{href: admin_main_dashboard_path}
       %img.img-fluid{src: asset_path("logo-no-text"), style: "max-width: 2rem;"}
       %small.font-weight-100 Admin
   .header-title.mt-1

--- a/app/views/admin/navigation/_sidebar.html.haml
+++ b/app/views/admin/navigation/_sidebar.html.haml
@@ -1,7 +1,7 @@
 %aside#AdminSidebar.sidebar
   .sidebar-brand
     %h1
-      %a{href: admin_dashboard_path}
+      %a{href: admin_main_dashboard_path}
         %img.img-fluid{src: asset_path("logo-no-text"), style: "max-width: 2rem;"}
         %span.text-primary.font-weight-900 Spectrum
         %small.font-weight-100 Admin
@@ -11,7 +11,7 @@
         %i.fas.fa-columns
         Dashboards
       %li.navigation-item
-        %a.navigation-link{class: active_by_path(admin_dashboard_path), href: admin_dashboard_path} Main
+        %a.navigation-link{class: active_by_path(admin_main_dashboard_path), href: admin_main_dashboard_path} Main
       %hr
       %li.navigation-title
         %i.fab.fa-ethereum

--- a/app/views/admin/navigation/_sidebar.html.haml
+++ b/app/views/admin/navigation/_sidebar.html.haml
@@ -12,6 +12,8 @@
         Dashboards
       %li.navigation-item
         %a.navigation-link{class: active_by_path(admin_main_dashboard_path), href: admin_main_dashboard_path} Main
+      %li.navigation-item
+        %a.navigation-link{class: active_by_path(admin_analytics_dashboard_path), href: admin_analytics_dashboard_path} Analytics
       %hr
       %li.navigation-title
         %i.fab.fa-ethereum
@@ -44,6 +46,10 @@
         %a.navigation-link{href: admin_payments_path} Payments
       %li.navigation-item
         %a.navigation-link{href: admin_refunds_path} Refunds
+      %hr
+      %li.navigation-title
+        %i.fas.fa-chart-line
+        Analytics
       %hr
       %li.navigation-title
         %i.fa.fa-globe

--- a/app/views/navigation/_header_links.html.haml
+++ b/app/views/navigation/_header_links.html.haml
@@ -15,8 +15,8 @@
     %a.nav-link{href: "https://medium.com/spectrum-trail-racing", target: "_blank"} Blog
   %li.nav-item
     - if current_user&.is_admin?
-      %a.nav-link.d-lg-none{href: admin_dashboard_path} Admin Dashboard
-      %a.btn.btn-sm.bg-primary.text-white.d-none.d-lg-inline-flex{href: admin_dashboard_path} Admin Dashboard
+      %a.nav-link.d-lg-none{href: admin_main_dashboard_path} Admin Dashboard
+      %a.btn.btn-sm.bg-primary.text-white.d-none.d-lg-inline-flex{href: admin_main_dashboard_path} Admin Dashboard
       %a.nav-link.d-lg-none{href: destroy_user_session_path} Sign Out
       %a.btn.btn-sm.bg-danger.text-white.d-none.d-lg-inline-flex{href: destroy_user_session_path} Sign Out
   .dropdown-divider.d-lg-none.my-4

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
     end
     get '/' => redirect('admin/main_dashboard')
     resource :main_dashboard, controller: 'main_dashboard'
+    resource :analytics_dashboard, controller: 'analytics_dashboard'
     resources :attachments, only: [:index]
     resources :discount_codes
     resources :events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,8 +48,8 @@ Rails.application.routes.draw do
     authenticate :user, lambda { |u| u.is_admin? } do
       mount Sidekiq::Web => '/sidekiq'
     end
-    get '/' => redirect('admin/dashboard')
-    resource :dashboard, controller: 'dashboard'
+    get '/' => redirect('admin/main_dashboard')
+    resource :main_dashboard, controller: 'main_dashboard'
     resources :attachments, only: [:index]
     resources :discount_codes
     resources :events


### PR DESCRIPTION
Rename dashboard to 'main_dashboard' to avoid confusion when adding future dashboards. Add an empty 'Analytics' dashboard to begin adding charts as we build out analytics based on database. Add a section to admin sidebar for analytics index pages. This should help us stay organized as we add metrics for business analysis and keep the main landing dashboard clean and easy to read.

-Rename main dashboard
-Add 'Analytics' admin dashboard
-Add 'Analytics' admin section