### PR TITLE
bugfix: add safe-nav to division #185

### DIFF
--- a/app/views/admin/participants/_card.html.haml
+++ b/app/views/admin/participants/_card.html.haml
@@ -29,7 +29,7 @@
     %li.list-group-item
       %strong.text-uppercase Division
       %br
-      = participant.division.titleize
+      = participant.division&.titleize
     %li.list-group-item
       %strong.text-uppercase Race Day Age
       %br


### PR DESCRIPTION
Addresses #185. This allows the participant card to render when .titleize is called in instances where the division has not yet been entered for in-progress registrations. Gives admins ability to view and edit in-progress registrations in these instances.