### PR TITLE
fix spacing issue on header with COVID-19 banner

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -20,6 +20,10 @@ html {
   font-size: 20px;
 }
 
+.header-with-covid-banner-spacer {
+  margin-top: ($spacer * 7.25);
+}
+
 #RuggedBox {
   background-color: $spectrum-blue;
 }

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -147,7 +147,7 @@ $spacers: map-merge((
   'sm': ($spacer * 2),
   'md': ($spacer * 4),
   'lg': ($spacer * 6),
-  'xl': ($spacer * 8)
+  'xl': ($spacer * 8),
 ), $spacers);
 
 // This variable affects the `.h-*` and `.w-*` classes.

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,7 +19,7 @@
       = render partial: "shared/drift_script"
   %body{class: "application #{controller_name}", id: "#{controller_name}_#{action_name}"}
     = render "navigation/dark_header"
-    %main.main
+    %main.main{ :class => ("header-with-covid-banner-spacer" unless current_page?(covid_path)) }
       = render partial: 'flash_messages', flash: flash
       = yield
     = render partial: "newsletter_signups/form"

--- a/app/views/static_pages/covid_procedures.html.haml
+++ b/app/views/static_pages/covid_procedures.html.haml
@@ -5,6 +5,5 @@
       .col
         .row.cols-xs-space.align-items-center.text-md-left.justify-content-center
           .col-lg-7
-            .mt-5
-              .covid-procedures-markdown
-                = markdown_file('covid.md')
+            .covid-procedures-markdown
+              = markdown_file('covid.md')


### PR DESCRIPTION
The fixed position of the header was causing the main page content to render behind the header. This became more pronounced after adding the COVID-19 banner and was interfering with certain page layouts, most noticeably race registration pages. Gives a more pleasant end user experience.

-Add custom "header-with-covid-banner" spacer to account for header height
-Render app main content with margin equal to current header height

[finishes #175444339]