### PR TITLE
dedicated volunteer registration space

### DIFF
--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -5,6 +5,19 @@ class VolunteersController < ApplicationController
   end
 
   def create
-    
+    @volunteer = Volunteer.create(volunteer_params)
+    if @volunteer
+      flash[:success] = 'Thank you for volunteering!'
+      redirect_to root_path
+    else
+      flash[:error] = 'Error saving volunteer registration, please try again.'
+      redirect_to new_volunteer_path
+    end
+  end
+
+  private
+
+  def volunteer_params
+    params.require(:volunteer).permit(:event_id, :first_name, :last_name, :phone, :email, :position, :time)
   end
 end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -1,0 +1,10 @@
+class VolunteersController < ApplicationController
+
+  def new
+    @volunteer = Volunteer.new
+  end
+
+  def create
+    
+  end
+end

--- a/app/controllers/volunteers_controller.rb
+++ b/app/controllers/volunteers_controller.rb
@@ -6,12 +6,15 @@ class VolunteersController < ApplicationController
 
   def create
     @volunteer = Volunteer.create(volunteer_params)
-    if @volunteer
+    if @volunteer.errors.messages[:email]
+      flash[:error] = @volunteer.errors.messages[:email][0]
+      redirect_to new_volunteer_path
+    elsif @volunteer.errors
+      flash[:error] = @volunteer.errors.messages
+      redirect_to new_volunteer_path
+    else
       flash[:success] = 'Thank you for volunteering!'
       redirect_to root_path
-    else
-      flash[:error] = 'Error saving volunteer registration, please try again.'
-      redirect_to new_volunteer_path
     end
   end
 

--- a/app/decorators/volunteer_decorator.rb
+++ b/app/decorators/volunteer_decorator.rb
@@ -1,0 +1,13 @@
+class VolunteerDecorator < ApplicationDecorator
+  delegate_all
+
+  # Define presentation-specific methods here. Helpers are accessed through
+  # `helpers` (aka `h`). You can override attributes, for example:
+  #
+  #   def created_at
+  #     helpers.content_tag :span, class: 'time' do
+  #       object.created_at.strftime("%a %m/%d/%y")
+  #     end
+  #   end
+
+end

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -9,6 +9,7 @@ class Event < ApplicationRecord
   has_many :races, dependent: :destroy
   has_many :registrations, counter_cache: true
   has_many :participants
+  has_many :volunteers
 
   # attachments
   has_one_attached :logo
@@ -26,6 +27,7 @@ class Event < ApplicationRecord
 
   scope :is_active, -> { where(is_active: true) }
   scope :by_starts_at, -> { order(starts_at: :asc) }
+  scope :volunteers, -> { joins(:volunteers) }
 
   def archived?
     archived_at.present?

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,0 +1,2 @@
+class Volunteer < ApplicationRecord
+end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -1,2 +1,10 @@
 class Volunteer < ApplicationRecord
+  belongs_to :event
+
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :phone, presence: true
+  validates :email, presence: true
+  validates :position, presence: true
+  validates :time, presence: true
 end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -4,7 +4,7 @@ class Volunteer < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :phone, presence: true
-  validates :email, presence: true
+  validates :email, presence: true, uniqueness: { message: "We\'re sorry, you can only volunteer for one event at a time." }
   validates :position, presence: true
   validates :time, presence: true
 end

--- a/app/views/navigation/_header_links.html.haml
+++ b/app/views/navigation/_header_links.html.haml
@@ -10,6 +10,8 @@
   %li.nav-item
     %a.nav-link{href: "https://store.spectrumtrailracing.com/store", target: "_blank"} Store
   %li.nav-item
+    %a.nav-link{href: new_volunteer_path} Volunteer
+  %li.nav-item
     %a.nav-link{href: "https://www.roguerunning.com/trail", target: "_blank"} Training
   %li.nav-item
     %a.nav-link{href: "https://medium.com/spectrum-trail-racing", target: "_blank"} Blog

--- a/app/views/volunteers/_form.html.haml
+++ b/app/views/volunteers/_form.html.haml
@@ -1,0 +1,15 @@
+%section
+  .container
+    .row.mt-5.mb-5.justify-content-center
+      .col
+        = simple_form_for @volunteer do |f|
+          .form-inputs
+            = f.association :event
+            = f.input :first_name, label: "First Name"
+            = f.input :last_name, label: "Last Name"
+            = f.input :phone, label: "Phone"
+            = f.input :email, label: "Email"
+            = f.input :position, label: "Preferred Position"
+            = f.input :time, :collection => %w[AM PM All\ Day]
+          .form-actions
+            = f.button :submit, "Submit", class: "btn btn-success btn-md"

--- a/app/views/volunteers/new.html.haml
+++ b/app/views/volunteers/new.html.haml
@@ -2,7 +2,16 @@
   .container
     .row
       .col-sm-12.col-md-4.col-lg-3.d-none.d-md-block
-        
+        .card.border-primary.bg-dark
+          .card-body.text-white
+            %h4.card-title.text-white Positions available:
+            %ul
+              %li Parking (AM)
+              %li Aid Station (AM & PM)
+              %li Finish Line
+              %li Pizza Kitchen (PM)
+              %li Course Tear Down (PM)
+
       .col-sm-12.col-md-8.col-lg-6
         .card.border-primary
           .card-body

--- a/app/views/volunteers/new.html.haml
+++ b/app/views/volunteers/new.html.haml
@@ -1,0 +1,13 @@
+%section.slice.slice-lg
+  .container
+    .row
+      .col-sm-12.col-md-4.col-lg-3.d-none.d-md-block
+        
+      .col-sm-12.col-md-8.col-lg-6
+        .card.border-primary
+          .card-body
+            %h4 Start your Volunteer Registration
+            %p
+              We are so excited you decided to help! Please be aware this does not obligate you or guarantee you a volunteer position. We will follow up with details!
+            %hr
+            = render "form"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,12 +29,12 @@ Rails.application.routes.draw do
       resources :participants, only: [:index]
     end
   end
+  put "newsletter_signup", to: "newsletter_signups#create"
+  match "*path/newsletter_signup", to: "newsletter_signups#create", via: :put
   resources :sponsors, only: [:index]
   resources :series, only: [:show]
   resources :team_members, path: "team", only: [:index, :show]
-
-  put "newsletter_signup", to: "newsletter_signups#create"
-  match "*path/newsletter_signup", to: "newsletter_signups#create", via: :put
+  resources :volunteers, only: [:new, :create, :edit, :update]
 
   namespace :members do
     resource :profile, controller: "profile", only: [:show, :edit, :update]

--- a/db/migrate/20201010012845_create_volunteers.rb
+++ b/db/migrate/20201010012845_create_volunteers.rb
@@ -1,0 +1,15 @@
+class CreateVolunteers < ActiveRecord::Migration[5.2]
+  def change
+    create_table :volunteers do |t|
+      t.references :event, foreign_key: true, index: true
+      t.string :first_name
+      t.string :last_name
+      t.string :phone
+      t.string :email
+      t.string :position
+      t.string :time
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_17_164731) do
+ActiveRecord::Schema.define(version: 2020_10_10_012845) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -356,6 +356,19 @@ ActiveRecord::Schema.define(version: 2020_02_17_164731) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  create_table "volunteers", force: :cascade do |t|
+    t.bigint "event_id"
+    t.string "first_name"
+    t.string "last_name"
+    t.string "phone"
+    t.string "email"
+    t.string "position"
+    t.string "time"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["event_id"], name: "index_volunteers_on_event_id"
+  end
+
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "events", "locations"
   add_foreign_key "participants", "events"
@@ -368,4 +381,5 @@ ActiveRecord::Schema.define(version: 2020_02_17_164731) do
   add_foreign_key "registrations", "discount_codes"
   add_foreign_key "registrations", "events"
   add_foreign_key "registrations", "users"
+  add_foreign_key "volunteers", "events"
 end


### PR DESCRIPTION
Add a volunteer landing page linked from the header. List information on volunteer positions. Add a form to register volunteers and persist to database. Streamlines the volunteering process and eliminates manual work saving time for the admins.

-Add "Volunteer" link to header
-Add "/volunteers" landing page
-Add positions card listing available positions
-Add volunteer registration form
-Save volunteer to database