### PR TITLE
show admin pending registrations value by race

### DIFF
--- a/app/decorators/race_decorator.rb
+++ b/app/decorators/race_decorator.rb
@@ -76,4 +76,8 @@ class RaceDecorator < ApplicationDecorator
       starts_at.strftime("%A %B %d, %Y")
     end
   end
+
+  def pending_revenue
+    race.participants.not_archived.abandoned_registrations.size * (race.price_in_cents / 100)
+  end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -40,6 +40,16 @@ class Participant < ApplicationRecord
   scope :for_start_list, -> do
     includes(:event).with_payment.not_cancelled.not_archived.order(:first_name)
   end
+  scope :incomplete_registrations, -> do
+    joins(:registration).where(registrations: { completed_at: nil })
+  end
+  scope :last_thirty_days, -> do
+    joins(:registration).where(registrations: { started_at: 1.month.ago..Time.now })
+  end
+  scope :over_twenty_four_hours, -> do
+    joins(:registration).where("started_at <= ?", 24.hours.ago)
+  end
+  scope :abandoned_registrations, -> { not_archived.incomplete_registrations.not_cancelled.last_thirty_days.over_twenty_four_hours }
 
   def full_name
     "#{first_name} #{last_name}".titleize

--- a/app/views/admin/races/_race_row.html.haml
+++ b/app/views/admin/races/_race_row.html.haml
@@ -5,6 +5,7 @@
     = race.start_date
     = race.start_time_with_zone
   %td= race.paid_participants_count.to_s + ' / ' + race.participants_cap.to_s
+  %td= number_to_currency(race.pending_revenue)
   %td
     .btn-group.float-right
       = link_to edit_admin_race_path(race),

--- a/app/views/admin/races/_table.html.haml
+++ b/app/views/admin/races/_table.html.haml
@@ -6,6 +6,7 @@
         %th{scope: "col"} Event
         %th{scope: "col"} Starts
         %th{scope: "col"} Participants
+        %th{scope: "col"} Pending Revenue
         %th{scope: "col"}
     %tbody
       - @races.each do |race|

--- a/spec/factories/participant.rb
+++ b/spec/factories/participant.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     email { "foobar@gmail.com" }
     phone { "3162588774" }
     birth_date { 30.years.ago }
+    division { "Male" }
     address { "3426 W Elizabeth St" }
     city { "Fort Collins" }
     state { "CO" }

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :registration do
-    accepts_refund_terms { true }
-    step_to_validate { "confirmation" }
+    step_to_validate { "details" }
 
     trait :paid do
       completed_at { Time.current }
@@ -10,12 +9,26 @@ FactoryBot.define do
         create(:payment, registration: registration)
       end
     end
+    trait :cancelled do
+      cancelled_at { Time.current }
+    end
+    trait :not_cancelled do
+      cancelled_at { nil }
+    end
     trait :incomplete do
       completed_at { nil }
-
-      after(:create) do |registration, evaluator|
-        create(:payment, registration: registration)
-      end
+    end
+    trait :last_thirty_days do
+      started_at { Time.current - 29.days }
+    end
+    trait :over_thirty_days do
+      started_at { Time.current - 31.days }
+    end
+    trait :over_twenty_four_hours do
+      started_at { Time.current - 25.hours }
+    end
+    trait :under_twenty_four_hours do
+      started_at { Time.current - 23.hours }
     end
   end
 end

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -10,5 +10,12 @@ FactoryBot.define do
         create(:payment, registration: registration)
       end
     end
+    trait :incomplete do
+      completed_at { nil }
+
+      after(:create) do |registration, evaluator|
+        create(:payment, registration: registration)
+      end
+    end
   end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -31,4 +31,154 @@ RSpec.describe Participant, type: :model do
       expect(participant_rows).to eq(Participant.count)
     end
   end
+
+  describe ".incomplete_registrations" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:incomplete_registration) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :incomplete, event: event)
+      )
+    }
+    let(:complete_registration) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :paid, event: event)
+      )
+    }
+
+    subject { Participant.incomplete_registrations }
+
+    it "includes participants with no completed_at timestamp on registration" do
+
+      expect(subject).to include(incomplete_registration)
+    end
+
+    it "excludes participants with completed_at timestamp on registration" do
+
+      expect(subject).not_to include(complete_registration)
+    end
+  end
+
+  describe ".not_cancelled" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:not_cancelled) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :not_cancelled, event: event)
+      )
+    }
+    let(:cancelled) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :cancelled, event: event)
+      )
+    }
+
+    subject { Participant.not_cancelled }
+
+    it "includes participants with no cancelled_at timestamp on registration" do
+
+      expect(subject).to include(not_cancelled)
+    end
+    it "excludes participants with a cancelled_at timestamp on registration" do
+
+      expect(subject).not_to include(cancelled)
+    end
+  end
+
+  describe ".last_thirty_days" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:last_thirty_days) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :last_thirty_days, event: event)
+      )
+    }
+    let!(:over_thirty_days) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :over_thirty_days, event: event)
+      )
+    }
+
+    subject { Participant.last_thirty_days }
+
+    it "includes participants with started_at timestamp within the last 30 days on registration" do
+
+      expect(subject).to include(last_thirty_days)
+    end
+
+    it "excludes participants with started_at timestamp older than 30 days on registration" do
+
+      expect(subject).not_to include(over_thirty_days)
+    end
+  end
+
+  describe ".over_twenty_four_hours" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:over_twenty_four_hours) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :over_twenty_four_hours, event: event)
+      )
+    }
+    let(:under_twenty_four_hours) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :under_twenty_four_hours, event: event)
+      )
+    }
+
+    subject { Participant.over_twenty_four_hours }
+
+    it "includes participants with started_at timestamp older than 24 hours on registration" do
+
+      expect(subject).to include(over_twenty_four_hours)
+    end
+    it "excludes participants with started_at timestamp under 24 hours on registration" do
+
+      expect(subject).not_to include(under_twenty_four_hours)
+    end
+  end
+
+  describe ".abandoned_registration" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:abandoned_registration) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :incomplete, :not_cancelled, :last_thirty_days, event: event)
+      )
+    }
+
+    subject { Participant.abandoned_registrations }
+
+    it "includes participants with registrations that are incomplete_registrations, not_cancelled, last_thirty_days, and over_twenty_four_hours" do
+
+      expect(subject).to include(abandoned_registration)
+    end
+  end
 end


### PR DESCRIPTION
Join registrations on participants to isolate opportunity data set. Render gross value to admin view in the Active Races table. Show admins value per opportunity for in-progress registrations by race. Can lead to increased ROI if pursued.

-Add 3 scopes to Participant model to join registrations where completed_at is nil, started_at is less than or equal to (older than) 24 hours ago, and started_at is within the last 1 month
-Add "Pending Revenue" column to Active Races admin page table
-Add table data to "Pending Revenue" column

[finishes #175443264]