### PR TITLE
remove canceled registrations from admin/races

### DIFF
--- a/app/decorators/race_decorator.rb
+++ b/app/decorators/race_decorator.rb
@@ -80,4 +80,8 @@ class RaceDecorator < ApplicationDecorator
   def pending_revenue
     race.participants.not_archived.abandoned_registrations.size * (race.price_in_cents / 100)
   end
+
+  def paid_not_cancelled_count
+    participants.not_archived.with_payment.not_cancelled.size
+  end
 end

--- a/app/views/admin/races/_race_row.html.haml
+++ b/app/views/admin/races/_race_row.html.haml
@@ -4,7 +4,7 @@
   %td
     = race.start_date
     = race.start_time_with_zone
-  %td= race.paid_participants_count.to_s + ' / ' + race.participants_cap.to_s
+  %td= race.paid_not_cancelled_count.to_s + ' / ' + race.participants_cap.to_s
   %td= number_to_currency(race.pending_revenue)
   %td
     .btn-group.float-right


### PR DESCRIPTION
Update logic to reflect participant count net of canceled races. Aligns with admin main dashboard Participation table logic. Provides admins consistent data for apples to apples comparison.

-Add paid_not_cancelled_count class method to Race model to show participants with a payment that are not canceled and not archived
-Update method call in admin/races "Participants" column table data

[finishes #175481859]