### PR TITLE
add abandoned registrations filter to admin

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -22,8 +22,12 @@ class Registration < ApplicationRecord
   scope :completed, -> { where.not(completed_at: nil) }
   scope :incomplete, -> { where(completed_at: nil) }
   scope :cancelled, -> { where.not(cancelled_at: nil) }
+  scope :not_cancelled, -> { where(cancelled_at: nil) }
   scope :archived, -> { where.not(archived_at: nil) }
   scope :not_archived, -> { where(archived_at: nil) }
+  scope :last_thirty_days, -> { where(started_at: 1.month.ago..Time.now) }
+  scope :over_twenty_four_hours, -> { where("started_at <= ?", 24.hours.ago) }
+  scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
 
   def archived?
     archived_at.present?

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -8,6 +8,9 @@
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :incomplete)), class: selected == 'incomplete' ? "active" : nil}
         %i.fas.fa-circle-notch.text-warning
         In-Progress
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :abandoned)), class: selected == 'abandoned' ? "active" : nil}
+        %i.fas.fa-circle-notch.text-warning
+        Abandoned
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :cancelled)), class: selected == 'cancelled' ? "active" : nil}
         %i.fa.fa-ban.text-danger
         Cancelled

--- a/spec/factories/participant.rb
+++ b/spec/factories/participant.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     email { "foobar@gmail.com" }
     phone { "3162588774" }
     birth_date { 30.years.ago }
+    division { "Male" }
     address { "3426 W Elizabeth St" }
     city { "Fort Collins" }
     state { "CO" }

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :registration do
-    accepts_refund_terms { true }
-    step_to_validate { "confirmation" }
+    step_to_validate { "details" }
 
     trait :paid do
       completed_at { Time.current }
@@ -9,6 +8,27 @@ FactoryBot.define do
       after(:create) do |registration, evaluator|
         create(:payment, registration: registration)
       end
+    end
+    trait :cancelled do
+      cancelled_at { Time.current }
+    end
+    trait :not_cancelled do
+      cancelled_at { nil }
+    end
+    trait :incomplete do
+      completed_at { nil }
+    end
+    trait :last_thirty_days do
+      started_at { Time.current - 29.days }
+    end
+    trait :over_thirty_days do
+      started_at { Time.current - 31.days }
+    end
+    trait :over_twenty_four_hours do
+      started_at { Time.current - 25.hours }
+    end
+    trait :under_twenty_four_hours do
+      started_at { Time.current - 23.hours }
     end
   end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -1,0 +1,192 @@
+require "rails_helper"
+
+RSpec.describe Registration, type: :model do
+  describe ".incomplete" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:incomplete) {
+      create(
+        :registration,
+        :incomplete,
+        event: event
+      )
+    }
+    let(:complete) {
+      create(
+        :registration,
+        :paid,
+        event: event
+      )
+    }
+
+    subject { Registration.incomplete }
+
+    it "includes registrations with no completed_at timestamp" do
+
+      expect(subject).to include(incomplete)
+    end
+
+    it "excludes registrations with completed_at timestamp" do
+
+      expect(subject).not_to include(complete)
+    end
+  end
+
+  describe ".not_cancelled" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:not_cancelled) {
+      create(
+        :registration,
+        :not_cancelled,
+        event: event
+      )
+    }
+    let(:cancelled) {
+      create(
+        :registration,
+        :cancelled,
+        event: event
+      )
+    }
+
+    subject { Registration.not_cancelled }
+
+    it "includes registrations with no cancelled_at timestamp" do
+
+      expect(subject).to include(not_cancelled)
+    end
+    it "excludes registrations with a cancelled_at timestamp" do
+
+      expect(subject).not_to include(cancelled)
+    end
+  end
+
+  describe ".last_thirty_days" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:last_thirty_days) {
+      create(
+        :registration,
+        :last_thirty_days,
+        event: event
+      )
+    }
+    let!(:over_thirty_days) {
+      create(
+        :registration,
+        :over_thirty_days,
+        event: event
+      )
+    }
+
+    subject { Registration.last_thirty_days }
+
+    it "includes registrations with started_at timestamp within the last 30 days" do
+
+      expect(subject).to include(last_thirty_days)
+    end
+
+    it "excludes registrations with started_at timestamp older than 30 days" do
+
+      expect(subject).not_to include(over_thirty_days)
+    end
+  end
+
+  describe ".over_twenty_four_hours" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:over_twenty_four_hours) {
+      create(
+        :registration,
+        :over_twenty_four_hours,
+        event: event
+      )
+    }
+    let(:under_twenty_four_hours) {
+      create(
+        :registration,
+        :under_twenty_four_hours,
+        event: event
+      )
+    }
+
+    subject { Registration.over_twenty_four_hours }
+
+    it "includes registrations with started_at timestamp older than 24 hours" do
+
+      expect(subject).to include(over_twenty_four_hours)
+    end
+    it "excludes registrations with started_at timestamp under 24 hours" do
+
+      expect(subject).not_to include(under_twenty_four_hours)
+    end
+  end
+
+  describe ".abandoned" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:abandoned) {
+      create(
+        :registration,
+        :incomplete,
+        :not_cancelled,
+        :last_thirty_days,
+        :over_twenty_four_hours,
+        event: event
+      )
+    }
+
+    subject { Registration.abandoned }
+
+    it "includes registrations that are incomplete_registrations, not_cancelled, last_thirty_days, and over_twenty_four_hours" do
+
+      expect(subject).to include(abandoned)
+    end
+  end
+end


### PR DESCRIPTION
Identify abandoned in-progress registrations. Allows admins to follow up with users to complete their registrations. Leads to increased revenue and customer feedback. 

-Add scopes to Registration model to isolate registrations that are incomplete, not cancelled, started in the last 30 days, and started over 24 hours ago (did not complete registration in first 24 hours)
-Add filter button to admin Registrations index page

[finishes #175482147] 