### PR TITLE
remove canceled registrations from filter logic

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -28,6 +28,7 @@ class Registration < ApplicationRecord
   scope :last_thirty_days, -> { where(started_at: 1.month.ago..Time.now) }
   scope :over_twenty_four_hours, -> { where("started_at <= ?", 24.hours.ago) }
   scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
+  scope :in_progress, -> { incomplete.not_cancelled }
 
   def archived?
     archived_at.present?

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -5,7 +5,7 @@
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :completed)), class: selected == 'completed' ? "active" : nil}
         %i.fas.fa-check-circle.text-success
         Complete
-      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :incomplete)), class: selected == 'incomplete' ? "active" : nil}
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :in_progress)), class: selected == 'incomplete' ? "active" : nil}
         %i.fas.fa-circle-notch.text-warning
         In-Progress
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :abandoned)), class: selected == 'abandoned' ? "active" : nil}


### PR DESCRIPTION
Update logic to show only non-cancelled in-progress registrations in admin registrations index page when in-progress filter is clicked. Provides more consistent data for admins.

-Add scope for in-progress registrations that chains the incomplete and not_cancelled scopes
-Update filter button to use in_progress scope

[finishes #175481859]