### PR TITLE
show admin total abandoned registrations per race

### DIFF
--- a/app/views/admin/races/_race_row.html.haml
+++ b/app/views/admin/races/_race_row.html.haml
@@ -5,6 +5,7 @@
     = race.start_date
     = race.start_time_with_zone
   %td= race.paid_not_cancelled_count.to_s + ' / ' + race.participants_cap.to_s
+  %td= race.participants.not_archived.abandoned_registrations.size
   %td= number_to_currency(race.pending_revenue)
   %td
     .btn-group.float-right

--- a/app/views/admin/races/_table.html.haml
+++ b/app/views/admin/races/_table.html.haml
@@ -6,6 +6,7 @@
         %th{scope: "col"} Event
         %th{scope: "col"} Starts
         %th{scope: "col"} Participants
+        %th{scope: "col"} Abandoned Registrations
         %th{scope: "col"} Pending Revenue
         %th{scope: "col"}
     %tbody


### PR DESCRIPTION
Render number of cumulative abandoned pending registrations by race to admin view in the Active Races table. Show admins how many abandoned registrations are pending by race. Accompanies #175443264 to provide actionable insight on pending revenue to follow up on. Can lead to increased ROI if pursued.

-Add "Abandoned Registrations" column to Active Races admin page table
-Add table data to "Abandoned Registrations" column

[finishes #175444013]