### PR TITLE
release 1.1 - a bunch'o scopes 

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -20,6 +20,10 @@ html {
   font-size: 20px;
 }
 
+.header-with-covid-banner-spacer {
+  margin-top: ($spacer * 7.25);
+}
+
 #RuggedBox {
   background-color: $spectrum-blue;
 }

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -147,7 +147,7 @@ $spacers: map-merge((
   'sm': ($spacer * 2),
   'md': ($spacer * 4),
   'lg': ($spacer * 6),
-  'xl': ($spacer * 8)
+  'xl': ($spacer * 8),
 ), $spacers);
 
 // This variable affects the `.h-*` and `.w-*` classes.

--- a/app/decorators/race_decorator.rb
+++ b/app/decorators/race_decorator.rb
@@ -76,4 +76,8 @@ class RaceDecorator < ApplicationDecorator
       starts_at.strftime("%A %B %d, %Y")
     end
   end
+
+  def pending_revenue
+    race.participants.not_archived.abandoned_registrations.size * (race.price_in_cents / 100)
+  end
 end

--- a/app/decorators/race_decorator.rb
+++ b/app/decorators/race_decorator.rb
@@ -80,4 +80,8 @@ class RaceDecorator < ApplicationDecorator
   def pending_revenue
     race.participants.not_archived.abandoned_registrations.size * (race.price_in_cents / 100)
   end
+
+  def paid_not_cancelled_count
+    participants.not_archived.with_payment.not_cancelled.size
+  end
 end

--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -40,6 +40,16 @@ class Participant < ApplicationRecord
   scope :for_start_list, -> do
     includes(:event).with_payment.not_cancelled.not_archived.order(:first_name)
   end
+  scope :incomplete_registrations, -> do
+    joins(:registration).where(registrations: { completed_at: nil })
+  end
+  scope :last_thirty_days, -> do
+    joins(:registration).where(registrations: { started_at: 30.days.ago..Time.now })
+  end
+  scope :over_twenty_four_hours, -> do
+    joins(:registration).where("started_at <= ?", 24.hours.ago)
+  end
+  scope :abandoned_registrations, -> { not_archived.incomplete_registrations.not_cancelled.last_thirty_days.over_twenty_four_hours }
 
   def full_name
     "#{first_name} #{last_name}".titleize

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -27,8 +27,9 @@ class Registration < ApplicationRecord
   scope :not_archived, -> { where(archived_at: nil) }
   scope :last_thirty_days, -> { where(started_at: 30.days.ago..Time.now) }
   scope :over_twenty_four_hours, -> { where("started_at <= ?", 24.hours.ago) }
-  scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
+  scope :complete, -> { completed.not_cancelled }
   scope :in_progress, -> { incomplete.not_cancelled }
+  scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
 
   def archived?
     archived_at.present?

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -28,6 +28,7 @@ class Registration < ApplicationRecord
   scope :last_thirty_days, -> { where(started_at: 30.days.ago..Time.now) }
   scope :over_twenty_four_hours, -> { where("started_at <= ?", 24.hours.ago) }
   scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
+  scope :in_progress, -> { incomplete.not_cancelled }
 
   def archived?
     archived_at.present?

--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -22,8 +22,12 @@ class Registration < ApplicationRecord
   scope :completed, -> { where.not(completed_at: nil) }
   scope :incomplete, -> { where(completed_at: nil) }
   scope :cancelled, -> { where.not(cancelled_at: nil) }
+  scope :not_cancelled, -> { where(cancelled_at: nil) }
   scope :archived, -> { where.not(archived_at: nil) }
   scope :not_archived, -> { where(archived_at: nil) }
+  scope :last_thirty_days, -> { where(started_at: 30.days.ago..Time.now) }
+  scope :over_twenty_four_hours, -> { where("started_at <= ?", 24.hours.ago) }
+  scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
 
   def archived?
     archived_at.present?

--- a/app/views/admin/races/_race_row.html.haml
+++ b/app/views/admin/races/_race_row.html.haml
@@ -4,7 +4,7 @@
   %td
     = race.start_date
     = race.start_time_with_zone
-  %td= race.paid_participants_count.to_s + ' / ' + race.participants_cap.to_s
+  %td= race.paid_not_cancelled_count.to_s + ' / ' + race.participants_cap.to_s
   %td= number_to_currency(race.pending_revenue)
   %td
     .btn-group.float-right

--- a/app/views/admin/races/_race_row.html.haml
+++ b/app/views/admin/races/_race_row.html.haml
@@ -5,6 +5,7 @@
     = race.start_date
     = race.start_time_with_zone
   %td= race.paid_not_cancelled_count.to_s + ' / ' + race.participants_cap.to_s
+  %td= race.participants.not_archived.abandoned_registrations.size
   %td= number_to_currency(race.pending_revenue)
   %td
     .btn-group.float-right

--- a/app/views/admin/races/_race_row.html.haml
+++ b/app/views/admin/races/_race_row.html.haml
@@ -5,6 +5,7 @@
     = race.start_date
     = race.start_time_with_zone
   %td= race.paid_participants_count.to_s + ' / ' + race.participants_cap.to_s
+  %td= number_to_currency(race.pending_revenue)
   %td
     .btn-group.float-right
       = link_to edit_admin_race_path(race),

--- a/app/views/admin/races/_table.html.haml
+++ b/app/views/admin/races/_table.html.haml
@@ -6,6 +6,7 @@
         %th{scope: "col"} Event
         %th{scope: "col"} Starts
         %th{scope: "col"} Participants
+        %th{scope: "col"} Pending Revenue
         %th{scope: "col"}
     %tbody
       - @races.each do |race|

--- a/app/views/admin/races/_table.html.haml
+++ b/app/views/admin/races/_table.html.haml
@@ -6,6 +6,7 @@
         %th{scope: "col"} Event
         %th{scope: "col"} Starts
         %th{scope: "col"} Participants
+        %th{scope: "col"} Abandoned Registrations
         %th{scope: "col"} Pending Revenue
         %th{scope: "col"}
     %tbody

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -8,6 +8,9 @@
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :incomplete)), class: selected == 'incomplete' ? "active" : nil}
         %i.fas.fa-circle-notch.text-warning
         In-Progress
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :abandoned)), class: selected == 'abandoned' ? "active" : nil}
+        %i.fas.fa-circle-notch.text-warning
+        Abandoned
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :cancelled)), class: selected == 'cancelled' ? "active" : nil}
         %i.fa.fa-ban.text-danger
         Cancelled

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -5,7 +5,7 @@
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :completed)), class: selected == 'completed' ? "active" : nil}
         %i.fas.fa-check-circle.text-success
         Complete
-      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :incomplete)), class: selected == 'incomplete' ? "active" : nil}
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :in_progress)), class: selected == 'incomplete' ? "active" : nil}
         %i.fas.fa-circle-notch.text-warning
         In-Progress
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :abandoned)), class: selected == 'abandoned' ? "active" : nil}

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -2,7 +2,7 @@
 .row.mb-2
   .col
     .btn-group
-      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :completed)), class: selected == 'completed' ? "active" : nil}
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :complete)), class: selected == 'completed' ? "active" : nil}
         %i.fas.fa-check-circle.text-success
         Complete
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :in_progress)), class: selected == 'incomplete' ? "active" : nil}

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -19,7 +19,7 @@
       = render partial: "shared/drift_script"
   %body{class: "application #{controller_name}", id: "#{controller_name}_#{action_name}"}
     = render "navigation/dark_header"
-    %main.main
+    %main.main{ :class => ("header-with-covid-banner-spacer" unless current_page?(covid_path)) }
       = render partial: 'flash_messages', flash: flash
       = yield
     = render partial: "newsletter_signups/form"

--- a/app/views/newsletter_signups/_form.html.haml
+++ b/app/views/newsletter_signups/_form.html.haml
@@ -1,7 +1,7 @@
 %section
   .container
-    .row.mt-5.mb-5.justify-content-center
-      .col
+    .row.justify-content-center
+      .col.my-5
         = simple_form_for :newsletter_signup,
           url: 'newsletter_signup',
           method: 'put',

--- a/app/views/static_pages/covid_procedures.html.haml
+++ b/app/views/static_pages/covid_procedures.html.haml
@@ -5,6 +5,5 @@
       .col
         .row.cols-xs-space.align-items-center.text-md-left.justify-content-center
           .col-lg-7
-            .mt-5
-              .covid-procedures-markdown
-                = markdown_file('covid.md')
+            .covid-procedures-markdown
+              = markdown_file('covid.md')

--- a/spec/factories/participant.rb
+++ b/spec/factories/participant.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     email { "foobar@gmail.com" }
     phone { "3162588774" }
     birth_date { 30.years.ago }
+    division { "Male" }
     address { "3426 W Elizabeth St" }
     city { "Fort Collins" }
     state { "CO" }

--- a/spec/factories/registration.rb
+++ b/spec/factories/registration.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :registration do
-    accepts_refund_terms { true }
-    step_to_validate { "confirmation" }
+    step_to_validate { "details" }
 
     trait :paid do
       completed_at { Time.current }
@@ -9,6 +8,27 @@ FactoryBot.define do
       after(:create) do |registration, evaluator|
         create(:payment, registration: registration)
       end
+    end
+    trait :cancelled do
+      cancelled_at { Time.current }
+    end
+    trait :not_cancelled do
+      cancelled_at { nil }
+    end
+    trait :incomplete do
+      completed_at { nil }
+    end
+    trait :last_thirty_days do
+      started_at { Time.current - 29.days }
+    end
+    trait :over_thirty_days do
+      started_at { Time.current - 31.days }
+    end
+    trait :over_twenty_four_hours do
+      started_at { Time.current - 25.hours }
+    end
+    trait :under_twenty_four_hours do
+      started_at { Time.current - 23.hours }
     end
   end
 end

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -31,4 +31,154 @@ RSpec.describe Participant, type: :model do
       expect(participant_rows).to eq(Participant.count)
     end
   end
+
+  describe ".incomplete_registrations" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:incomplete_registration) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :incomplete, event: event)
+      )
+    }
+    let(:complete_registration) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :paid, event: event)
+      )
+    }
+
+    subject { Participant.incomplete_registrations }
+
+    it "includes participants with no completed_at timestamp on registration" do
+
+      expect(subject).to include(incomplete_registration)
+    end
+
+    it "excludes participants with completed_at timestamp on registration" do
+
+      expect(subject).not_to include(complete_registration)
+    end
+  end
+
+  describe ".not_cancelled" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:not_cancelled) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :not_cancelled, event: event)
+      )
+    }
+    let(:cancelled) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :cancelled, event: event)
+      )
+    }
+
+    subject { Participant.not_cancelled }
+
+    it "includes participants with no cancelled_at timestamp on registration" do
+
+      expect(subject).to include(not_cancelled)
+    end
+    it "excludes participants with a cancelled_at timestamp on registration" do
+
+      expect(subject).not_to include(cancelled)
+    end
+  end
+
+  describe ".last_thirty_days" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:last_thirty_days) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :last_thirty_days, event: event)
+      )
+    }
+    let!(:over_thirty_days) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :over_thirty_days, event: event)
+      )
+    }
+
+    subject { Participant.last_thirty_days }
+
+    it "includes participants with started_at timestamp within the last 30 days on registration" do
+
+      expect(subject).to include(last_thirty_days)
+    end
+
+    it "excludes participants with started_at timestamp older than 30 days on registration" do
+
+      expect(subject).not_to include(over_thirty_days)
+    end
+  end
+
+  describe ".over_twenty_four_hours" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:over_twenty_four_hours) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :over_twenty_four_hours, event: event)
+      )
+    }
+    let(:under_twenty_four_hours) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :under_twenty_four_hours, event: event)
+      )
+    }
+
+    subject { Participant.over_twenty_four_hours }
+
+    it "includes participants with started_at timestamp older than 24 hours on registration" do
+
+      expect(subject).to include(over_twenty_four_hours)
+    end
+    it "excludes participants with started_at timestamp under 24 hours on registration" do
+
+      expect(subject).not_to include(under_twenty_four_hours)
+    end
+  end
+
+  describe ".abandoned_registration" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:abandoned_registration) {
+      create(
+        :participant,
+        event: event,
+        race: event.races.first,
+        registration: create(:registration, :incomplete, :not_cancelled, :last_thirty_days, event: event)
+      )
+    }
+
+    subject { Participant.abandoned_registrations }
+
+    it "includes participants with registrations that are incomplete_registrations, not_cancelled, last_thirty_days, and over_twenty_four_hours" do
+
+      expect(subject).to include(abandoned_registration)
+    end
+  end
 end

--- a/spec/models/registration_spec.rb
+++ b/spec/models/registration_spec.rb
@@ -1,0 +1,192 @@
+require "rails_helper"
+
+RSpec.describe Registration, type: :model do
+  describe ".incomplete" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:incomplete) {
+      create(
+        :registration,
+        :incomplete,
+        event: event
+      )
+    }
+    let(:complete) {
+      create(
+        :registration,
+        :paid,
+        event: event
+      )
+    }
+
+    subject { Registration.incomplete }
+
+    it "includes registrations with no completed_at timestamp" do
+
+      expect(subject).to include(incomplete)
+    end
+
+    it "excludes registrations with completed_at timestamp" do
+
+      expect(subject).not_to include(complete)
+    end
+  end
+
+  describe ".not_cancelled" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:not_cancelled) {
+      create(
+        :registration,
+        :not_cancelled,
+        event: event
+      )
+    }
+    let(:cancelled) {
+      create(
+        :registration,
+        :cancelled,
+        event: event
+      )
+    }
+
+    subject { Registration.not_cancelled }
+
+    it "includes registrations with no cancelled_at timestamp" do
+
+      expect(subject).to include(not_cancelled)
+    end
+    it "excludes registrations with a cancelled_at timestamp" do
+
+      expect(subject).not_to include(cancelled)
+    end
+  end
+
+  describe ".last_thirty_days" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:last_thirty_days) {
+      create(
+        :registration,
+        :last_thirty_days,
+        event: event
+      )
+    }
+    let!(:over_thirty_days) {
+      create(
+        :registration,
+        :over_thirty_days,
+        event: event
+      )
+    }
+
+    subject { Registration.last_thirty_days }
+
+    it "includes registrations with started_at timestamp within the last 30 days" do
+
+      expect(subject).to include(last_thirty_days)
+    end
+
+    it "excludes registrations with started_at timestamp older than 30 days" do
+
+      expect(subject).not_to include(over_thirty_days)
+    end
+  end
+
+  describe ".over_twenty_four_hours" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:over_twenty_four_hours) {
+      create(
+        :registration,
+        :over_twenty_four_hours,
+        event: event
+      )
+    }
+    let(:under_twenty_four_hours) {
+      create(
+        :registration,
+        :under_twenty_four_hours,
+        event: event
+      )
+    }
+
+    subject { Registration.over_twenty_four_hours }
+
+    it "includes registrations with started_at timestamp older than 24 hours" do
+
+      expect(subject).to include(over_twenty_four_hours)
+    end
+    it "excludes registrations with started_at timestamp under 24 hours" do
+
+      expect(subject).not_to include(under_twenty_four_hours)
+    end
+  end
+
+  describe ".abandoned" do
+    let!(:race) { create :race }
+    let!(:event) { race.event }
+    let(:participants) do
+      1.times do
+        create(
+          :participant,
+          event: event,
+          race: event.races.first
+        )
+      end
+    end
+    let(:abandoned) {
+      create(
+        :registration,
+        :incomplete,
+        :not_cancelled,
+        :last_thirty_days,
+        :over_twenty_four_hours,
+        event: event
+      )
+    }
+
+    subject { Registration.abandoned }
+
+    it "includes registrations that are incomplete_registrations, not_cancelled, last_thirty_days, and over_twenty_four_hours" do
+
+      expect(subject).to include(abandoned)
+    end
+  end
+end


### PR DESCRIPTION
show admin pending registrations value by race

Join registrations on participants to isolate opportunity data set. Render gross value to admin view in the Active Races table. Show admins value per opportunity for in-progress registrations by race. Can lead to increased ROI if pursued.
-Add 3 scopes to Participant model to join registrations where completed_at is nil, started_at is less than or equal to (older than) 24 hours ago, and started_at is within the last 1 month -Add "Pending Revenue" column to Active Races admin page table -Add table data to "Pending Revenue" column
[finishes #175443264]

remove canceled registrations from admin/races

Update logic to reflect participant count net of canceled races. Aligns with admin main dashboard Participation table logic. Provides admins consistent data for apples to apples comparison.
-Add paid_not_cancelled_count class method to Race model to show participants with a payment that are not canceled and not archived -Update method call in admin/races "Participants" column table data
[finishes #175481859]

add abandoned registrations filter to admin

Add filter button for abandoned in-progress registrations. Allows admins to follow up with users to complete their registrations. Leads to increased revenue and customer feedback.
-Add scopes to Registration model to isolate registrations that are incomplete, not cancelled, started in the last 30 days, and started over 24 hours ago (did not complete registration in first 24 hours) -Add filter button to admin Registrations index page
[finishes #175482147]

remove canceled registrations from filter logic

Update logic to show only non-cancelled in-progress registrations in admin registrations index page when in-progress filter is clicked. Provides more consistent data for admins.
-Add scope for in-progress registrations that chains the incomplete and not_cancelled scopes -Update filter button to use in_progress scope
[finishes #175481859]

show admin total abandoned registrations per race

Render number of cumulative abandoned pending registrations by race to admin view in the Active Races table. Accompanies #175443264 to provide actionable insight on pending registration revenue to follow up on. Can lead to increased ROI if pursued.
-Add "Abandoned Registrations" column to Active Races admin page table -Add table data to "Abandoned Registrations" column
[finishes #175444013]

fix spacing issue on header with COVID-19 banner

Adjust app layout to account for fixed header height. The fixed position of the header was causing the main page content to render behind the header. This became more pronounced after adding the COVID-19 banner and was interfering with certain page layouts, most noticeably race registration pages. Gives a more pleasant end user experience.
-Add custom "header-with-covid-banner" spacer to account for header height
-Render app main content with margin equal to current header height
[finishes #175444339]

remove canceled registrations from complete filter

Update filter results for complete registrations to only show completed registrations that have not been cancelled. Add complete scope to chain completed and not_cancelled. Show admins consistent results across registration filters.
-Add complete registration scope to be completed and not_cancelled
-Update complete filter scope for filter button
[finishes #175560527]