### PR TITLE
remove canceled registrations from complete filter

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -27,8 +27,9 @@ class Registration < ApplicationRecord
   scope :not_archived, -> { where(archived_at: nil) }
   scope :last_thirty_days, -> { where(started_at: 1.month.ago..Time.now) }
   scope :over_twenty_four_hours, -> { where("started_at <= ?", 24.hours.ago) }
-  scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
+  scope :complete, -> { completed.not_cancelled }
   scope :in_progress, -> { incomplete.not_cancelled }
+  scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
 
   def archived?
     archived_at.present?

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -2,7 +2,7 @@
 .row.mb-2
   .col
     .btn-group
-      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :completed)), class: selected == 'completed' ? "active" : nil}
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :complete)), class: selected == 'completed' ? "active" : nil}
         %i.fas.fa-check-circle.text-success
         Complete
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :in_progress)), class: selected == 'incomplete' ? "active" : nil}


### PR DESCRIPTION
Update filter results for complete registrations to only show completed registrations that have not been cancelled. Add complete scope to chain completed and not_cancelled. Show admins consistent results across registration filters.

-Add complete registration scope to be completed and not_cancelled
-Update complete filter scope for filter button

[finishes #175560527]