### PR TITLE
refactor app layout for fixed header

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -20,8 +20,9 @@ html {
   font-size: 20px;
 }
 
-.header-with-covid-banner-spacer {
-  margin-top: ($spacer * 7.25);
+.fixed-header-spacer {
+  height: ($spacer * 7.25);
+  width: 100%;
 }
 
 #RuggedBox {

--- a/app/assets/stylesheets/_global.scss
+++ b/app/assets/stylesheets/_global.scss
@@ -17,7 +17,7 @@
 
 @include media-breakpoint-up(md) {
   .parallaxy {
-    background-position: center center;
+    background-position: center top;
     background-attachment: fixed; // makes it parallaxy
   }
 }

--- a/app/views/events/sections/_landing_spotlight.html.haml
+++ b/app/views/events/sections/_landing_spotlight.html.haml
@@ -5,7 +5,7 @@
       .col
         .row.cols-xs-space.text-center.text-md-left.justify-content-center
           .col-lg-10
-            .text-center.mt-5
+            .text-center
               %small.text-muted= @event.starts_at_date_string
               %h1.heading.h1.text-white= @event.name.upcase
               %p.lead.lh-180.text-white.mt-3= @event.short_description

--- a/app/views/events/sections/_menu.html.haml
+++ b/app/views/events/sections/_menu.html.haml
@@ -1,4 +1,4 @@
-.card.bg-black.sticky-top.sticky-top-offset-4.mb-3
+.card.bg-black.sticky-top.sticky-top-offset-8.mb-3
   %img.img-fluid.img-center{src: @event.default_logo_url}
   #EventMenu.list-group
     %a.list-group-item.list-group-item-action.d-flex.align-items-center{href: "#RegistrationSection"} Registration

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -18,8 +18,9 @@
     - if Rails.env.production?
       = render partial: "shared/drift_script"
   %body{class: "application #{controller_name}", id: "#{controller_name}_#{action_name}"}
+    = render "navigation/fixed_header_spacer"
     = render "navigation/dark_header"
-    %main.main{ :class => ("header-with-covid-banner-spacer" unless current_page?(covid_path)) }
+    %main.main
       = render partial: 'flash_messages', flash: flash
       = yield
     = render partial: "newsletter_signups/form"

--- a/app/views/navigation/_fixed_header_spacer.html.haml
+++ b/app/views/navigation/_fixed_header_spacer.html.haml
@@ -1,0 +1,1 @@
+%section{ :class => ("fixed-header-spacer" unless current_page?(covid_path)) }

--- a/app/views/shared/sections/_home_landing_cover.html.haml
+++ b/app/views/shared/sections/_home_landing_cover.html.haml
@@ -5,7 +5,7 @@
       .col
         .row.cols-xs-space.text-center.text-md-left.justify-content-center
           .col-lg-10
-            .text-center.mt-5
+            .text-center
               %h1.text-white.nanum
                 Welcome to a community of hard-working, big loving trailblazers.
                 %br


### PR DESCRIPTION
Refactor the spacer to render a section in the app layout instead of dynamically adding a class to %main. This moves the main section to start at the bottom of the header section. There was still some crowded elements after adding the covid banner spacer, most noticeably on the landing pages and events scrollspy section. Gives a more pleasant user experience.

-Rename spacer class .fixed-header-spacer
-Add fixed header section in /navigation
-Render fixed header spacer in app layout
-Remove margin-top from landing sections
-Adjust sticky-top-offset for events overview
-Adjust parallaxy class for image placement