### PR TITLE
reorder admin canceled registrations list

### DIFF
--- a/app/models/registration.rb
+++ b/app/models/registration.rb
@@ -30,6 +30,7 @@ class Registration < ApplicationRecord
   scope :complete, -> { completed.not_cancelled }
   scope :in_progress, -> { incomplete.not_cancelled }
   scope :abandoned, -> { incomplete.not_cancelled.last_thirty_days.over_twenty_four_hours }
+  scope :cancelled_ordered_by_cancelled_at, -> { cancelled.order(cancelled_at: :desc) }
 
   def archived?
     archived_at.present?

--- a/app/views/admin/registrations/_filter_button_group.html.haml
+++ b/app/views/admin/registrations/_filter_button_group.html.haml
@@ -11,7 +11,7 @@
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :abandoned)), class: selected == 'abandoned' ? "active" : nil}
         %i.fas.fa-circle-notch.text-warning
         Abandoned
-      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :cancelled)), class: selected == 'cancelled' ? "active" : nil}
+      %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path(request.params.merge(filter_scope: :cancelled_ordered_by_cancelled_at)), class: selected == 'cancelled_ordered_by_cancelled_at' ? "active" : nil}
         %i.fa.fa-ban.text-danger
         Cancelled
       %a.btn.btn-sm.btn-outline-primary{href: admin_registrations_path, class: selected == nil ? "active" : nil}


### PR DESCRIPTION
Add new scope to reorder canceled registrations. Shows admins more meaningful sort order.

-add cancelled_ordered_by_cancelled_at scope
-update cancelled filter button scope call
[finishes #175604274]