### PR TITLE
refactor newsletter signup service

### DIFF
--- a/app/controllers/newsletter_signups_controller.rb
+++ b/app/controllers/newsletter_signups_controller.rb
@@ -1,23 +1,22 @@
 class NewsletterSignupsController < ApplicationController
 
+  NewsletterSignup = Struct.new(:first_name, :last_name, :email, keyword_init: true)
+
   def create
-    signup = CreateNewsletterSignup.new(
+    newsletter_signup = NewsletterSignup.new(
       {
         first_name: newsletter_signup_params[:first_name],
         last_name: newsletter_signup_params[:last_name],
         email: newsletter_signup_params[:email]
       }
-    ).perform
+    )
 
-    if signup.class == SendGrid::Response
-      response = JSON.parse(signup.body)
-      if response['errors']
-        redirect_back(fallback_location: root_path, error: response['errors'][0]['message'])
-      else
-        redirect_back(fallback_location: root_path, success: 'Thank you for signing up!')
-      end
+    result = CreateNewsletterSignup.new(**newsletter_signup.to_h).perform
+
+    if result.success
+      redirect_back(fallback_location: root_path, success: result.flash_message)
     else
-      redirect_back(fallback_location: root_path, error: 'There was a problem with your request, please try again.')
+      flash[:error] = result.flash_message
     end
   end
 

--- a/app/services/create_newsletter_signup.rb
+++ b/app/services/create_newsletter_signup.rb
@@ -13,12 +13,20 @@ class CreateNewsletterSignup
   end
 
   def perform
-    signup_api_call
+    sendgrid_api_call
   end
 
   private
 
-  def signup_api_call
+  def catch_exception(exception)
+    ServiceResponse.new(
+      message: exception.message + ' Please try again.',
+      object: exception,
+      success: false
+    )
+  end
+
+  def sendgrid_api_call
     api_call_data = {
       'list_ids' => list_ids,
       'contacts' => [
@@ -29,5 +37,20 @@ class CreateNewsletterSignup
     }
     sg = SendGrid::API.new(api_key: api_key)
     response = sg.client.marketing.contacts.put(request_body: api_call_data)
+    if response.status_code == '202'
+      ServiceResponse.new(
+        message: 'Thank you for signing up!',
+        object: response,
+        success: true
+      )
+    else
+      ServiceResponse.new(
+        message: 'Something went wrong, please try again.',
+        object: response,
+        success: false
+      )
+    end
+  rescue => e
+    catch_exception(e)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,14 +29,13 @@ Rails.application.routes.draw do
       resources :participants, only: [:index]
     end
   end
+  put "newsletter_signup", to: "newsletter_signups#create"
+  match "*path/newsletter_signup", to: "newsletter_signups#create", via: :put
   resources :sponsors, only: [:index]
   resources :series, only: [:show]
   resources :team_members, path: "team", only: [:index, :show]
   get "/volunteer", to: "volunteers#new"
   resources :volunteers, only: [:create, :show]
-
-  put "newsletter_signup", to: "newsletter_signups#create"
-  match "*path/newsletter_signup", to: "newsletter_signups#create", via: :put
 
   namespace :members do
     resource :profile, controller: "profile", only: [:show, :edit, :update]

--- a/spec/services/create_newsletter_signup_spec.rb
+++ b/spec/services/create_newsletter_signup_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe CreateNewsletterSignup do
-  let(:newsletter_signup) {
+  subject {
     CreateNewsletterSignup.new(
         {
           first_name: "Will",
@@ -13,29 +13,39 @@ RSpec.describe CreateNewsletterSignup do
       )
   }
 
+  describe CreateNewsletterSignup do
+    it "exists" do
+      expect(subject).to be_a(CreateNewsletterSignup)
+    end
+  end
+
   describe "newsletter signup object" do
     it "accepts a first name, last name, and email" do
-      expect(newsletter_signup.first_name).to eq('Will')
-      expect(newsletter_signup.last_name).to eq('Blake')
-      expect(newsletter_signup.email).to eq('test@test.com')
-      expect(newsletter_signup.api_key).to eq('ThisIsNotTheRealKey')
-      expect(newsletter_signup.list_ids).to eq(['ThisIsNotTheRealListId'])
+      expect(subject.first_name).to eq('Will')
+      expect(subject.last_name).to eq('Blake')
+      expect(subject.email).to eq('test@test.com')
+      expect(subject.api_key).to eq('ThisIsNotTheRealKey')
+      expect(subject.list_ids).to eq(['ThisIsNotTheRealListId'])
     end
   end
 
   describe "#perform" do
     it "sends a signup request to SendGrid api" do
-      stub_request(:put, "https://api.sendgrid.com/v3/marketing/contacts").
+      stub = stub_request(:put, "https://api.sendgrid.com/v3/marketing/contacts").
         with(
-          body: "{\"list_ids\":[\"newsletter_signup.list_ids\"],\"contacts\":[{\"first_name\":\"Will\",\"last_name\":\"Blake\",\"email\":\"test@test.com\"}]}",
+          body: "{\"list_ids\":" + subject.list_ids.to_s + ",\"contacts\":[{\"first_name\":\"Will\",\"last_name\":\"Blake\",\"email\":\"test@test.com\"}]}",
           headers: {
-        'Accept'=>'application/json',
-        'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
-        'Authorization' => newsletter_signup.api_key,
-        'Content-Type'=>'application/json',
-        'User-Agent'=>'sendgrid/5.3.0;ruby'
+            'Accept'=>'application/json',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Authorization' => "Bearer " + subject.api_key,
+            'Content-Type'=>'application/json',
+            'User-Agent'=>'sendgrid/5.3.0;ruby'
           }).
         to_return(status: 200, body: "", headers: {})
+
+      subject.perform
+
+      expect(stub).to have_been_requested
     end
   end
 end


### PR DESCRIPTION
More elegant and streamlined in less lines of code.

-refactor newsletter signup controller to use a struct and double splat
-reduce error handling to a rescue block
-rename api call method
-refactor .perform method test
-add exists test to verify class of object
-return service response object from .perform
[finishes #175460247]