### PR TITLE
update volunteers table

### DIFF
--- a/db/migrate/20210114172305_change_active_default_to_true.rb
+++ b/db/migrate/20210114172305_change_active_default_to_true.rb
@@ -1,0 +1,5 @@
+class ChangeActiveDefaultToTrue < ActiveRecord::Migration[5.2]
+  def change
+    change_column_default :volunteers, :active, from: nil, to: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -372,7 +372,7 @@ ActiveRecord::Schema.define(version: 2020_12_08_155901) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "volunteer_position_id"
-    t.boolean "active"
+    t.boolean "active", default: true
     t.index ["event_id"], name: "index_volunteers_on_event_id"
     t.index ["volunteer_position_id"], name: "index_volunteers_on_volunteer_position_id"
   end


### PR DESCRIPTION
Renames column to align with schema naming convention. Allows volunteers to register as is_active to eliminate manual work for admins.

-Change column name from active to is_active
-Sets default to true