### PR TITLE
admin volunteer dashboard space

### DIFF
--- a/app/controllers/admin/volunteers_controller.rb
+++ b/app/controllers/admin/volunteers_controller.rb
@@ -1,0 +1,73 @@
+class Admin::VolunteersController < Admin::BaseController
+  before_action :set_volunteer, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @volunteers = fetch_volunteers
+    @volunteers = @volunteers.page(params[:page])
+  end
+
+  def show
+  end
+
+  def new
+    @volunteer = Volunteer.new
+  end
+
+  def edit
+  end
+
+  def create
+    @volunteer = Volunteer.new(volunteer_params)
+
+    if @volunteer.save
+      redirect_to(
+        admin_volunteers_path(@volunteer),
+        success: "Successfully created #{@volunteer.full_name}"
+      )
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @volunteer.update(volunteer_params)
+      redirect_to(
+        admin_volunteers_path,
+        success: "Successfully updated #{@volunteer.full_name}"
+      )
+    else
+      flash[:danger] = "Could not update this event. Please see errors."
+      render :edit
+    end
+  end
+
+  def destroy
+    @volunteer.destroy
+    redirect_to(
+      admin_volunteers_path,
+      success: "Successfully destroyed #{@volunteer.full_name}"
+    )
+  end
+
+  private
+
+  def fetch_volunteers
+    volunteers = Volunteer.includes(:event)
+
+    if params[:event_id].present?
+      volunteers = volunteers.where(event_id: params[:event_id])
+    end
+
+    volunteers.send(
+      params.fetch(:filter_scope, :all)
+    ).order(created_at: :desc)
+  end
+
+  def set_volunteer
+    @volunteer = Volunteer.find(params[:id]).decorate
+  end
+
+  def volunteer_params
+    params.require(:volunteer).permit!
+  end
+end

--- a/app/decorators/volunteer_decorator.rb
+++ b/app/decorators/volunteer_decorator.rb
@@ -1,13 +1,5 @@
 class VolunteerDecorator < ApplicationDecorator
-  delegate_all
-
-  # Define presentation-specific methods here. Helpers are accessed through
-  # `helpers` (aka `h`). You can override attributes, for example:
-  #
-  #   def created_at
-  #     helpers.content_tag :span, class: 'time' do
-  #       object.created_at.strftime("%a %m/%d/%y")
-  #     end
-  #   end
-
+  def full_name
+    "#{first_name} #{last_name}"
+  end
 end

--- a/app/models/volunteer.rb
+++ b/app/models/volunteer.rb
@@ -7,4 +7,7 @@ class Volunteer < ApplicationRecord
   validates :phone, presence: true
   validates :email, presence: true, uniqueness: { scope: :event }
   validates :time, presence: true
+
+  scope :active, -> { where(active: true) }
+  scope :inactive, -> { where(active: false) }
 end

--- a/app/views/admin/events/_event_row.html.haml
+++ b/app/views/admin/events/_event_row.html.haml
@@ -29,6 +29,9 @@
         = link_to admin_registrations_path(event_id: event.id), class: "dropdown-item" do
           %i.fa.fa-users
           Registrations
+        = link_to admin_volunteers_path(event_id: event.id), class: "dropdown-item" do
+          %i.fa.fa-handshake
+          Volunteers
         = link_to admin_event_path(event), class: "dropdown-item" do
           %i.fa.fa-tachometer-alt
           Dashboard

--- a/app/views/admin/navigation/_sidebar.html.haml
+++ b/app/views/admin/navigation/_sidebar.html.haml
@@ -21,6 +21,8 @@
       %li.navigation-item
         %a.navigation-link{href: admin_events_path} Events
       %li.navigation-item
+      %a.navigation-link{href: admin_volunteers_path} Volunteers
+      %li.navigation-item
         %a.navigation-link{href: admin_locations_path} Locations
       %li.navigation-item
         %a.navigation-link{href: admin_mailings_path} Mailings

--- a/app/views/admin/volunteers/_filter_button_group.html.haml
+++ b/app/views/admin/volunteers/_filter_button_group.html.haml
@@ -1,0 +1,13 @@
+- selected = params[:filter_scope]
+.row.mb-2
+  .col
+    .btn-group
+      %a.btn.btn-sm.btn-outline-primary{href: admin_volunteers_path(request.params.merge(filter_scope: :active)), class: selected == 'active' ? "active" : nil}
+        %i.fas.fa-check-circle.text-success
+        Active
+      %a.btn.btn-sm.btn-outline-primary{href: admin_volunteers_path(request.params.merge(filter_scope: :inactive)), class: selected == 'inactive' ? "active" : nil}
+        %i.fas.fa-ban.text-warning
+        Inactive
+      %a.btn.btn-sm.btn-outline-primary{href: admin_volunteers_path, class: selected == nil ? "active" : nil}
+        %i.fa.fa-list
+        ALL

--- a/app/views/admin/volunteers/_form.html.haml
+++ b/app/views/admin/volunteers/_form.html.haml
@@ -1,0 +1,38 @@
+-# frozen_string_literal: true
+= simple_form_for([:admin, @volunteer], validate: true, html: { id: "AdminVolunteersForm" }) do |f|
+  = f.error_notification
+  - if f.object.errors[:base].present?
+    = f.error_notification message: f.object.errors[:base].to_sentence
+  .form-inputs
+    %fieldset
+      %legend Active
+      = f.input :active,
+        as: :radio_buttons,
+        label: "Is Active?",
+        hint: "Inactive volunteers are highlighted in red"
+
+    %fieldset
+      %legend Details
+      %p.text-muted If you need to change the event please delete this volunteer and create a new one under the correct event
+      = f.input :volunteer_position_id, label: "Position", collection: @volunteer.event.volunteer_positions, prompt: "select a position",
+        input_html: { class: "editor textarea-autosize" },
+        hint: "If you don't see the position you need you can manage them from the events admin space"
+      = f.input :time, label: "Time", collection: %w[AM PM All\ Day],
+        input_html: { class: "editor textarea-autosize" }
+      = f.input :first_name,
+        input_html: { class: "editor textarea-autosize" }
+      = f.input :last_name,
+        input_html: { class: "editor textarea-autosize" }
+      = f.input :email,
+        input_html: { class: "editor textarea-autosize" }
+
+  %br
+  .form-actions
+    = link_to admin_volunteers_path,
+      class: "mr-2 btn btn-md btn-outline-secondary",
+      data: { confirm: "Careful! You will lose any progress you made on this form."} do
+      %i.fas.fa-arrow-left
+      Go Back
+    = f.button :submit,
+      class: "btn btn-md btn-outline-success",
+      data: { disable_with: "Submitting..." }

--- a/app/views/admin/volunteers/_table.html.haml
+++ b/app/views/admin/volunteers/_table.html.haml
@@ -1,0 +1,14 @@
+.card.mb-4
+  %table.table.table-responsive-md
+    %thead.thead-light
+      %tr
+        %th{scope: "col"} Event
+        %th{scope: "col"} Position
+        %th{scope: "col"} Time
+        %th{scope: "col"} First Name
+        %th{scope: "col"} Last Name
+        %th{scope: "col"} Email
+        %th{scope: "col"}
+    %tbody
+      - @volunteers.each do |volunteer|
+        = render "volunteer_row", volunteer: volunteer

--- a/app/views/admin/volunteers/_volunteer_row.html.haml
+++ b/app/views/admin/volunteers/_volunteer_row.html.haml
@@ -1,0 +1,26 @@
+%tr{class: !volunteer.active? ? "table-danger" : ""}
+  %td
+    -# %img.avatar.avatar-sm{src: volunteer.event.row_thumbnail}
+    = volunteer.event.name
+  %td
+    = volunteer.volunteer_position.name
+  %td
+    = volunteer.time
+  %td
+    = volunteer.first_name
+  %td
+    = volunteer.last_name
+  %td
+    = volunteer.email
+  %td
+    .btn-group.float-right
+      = link_to edit_admin_volunteer_path(volunteer),
+        class: "btn btn-sm btn-outline-primary" do
+        %i.fa.fa-edit
+        Edit
+      = link_to admin_volunteer_path(volunteer),
+        method: :delete,
+        data: { confirm: "Are you sure?" },
+        class: "btn btn-sm btn-outline-danger" do
+        %i.fas.fa-trash
+        Delete

--- a/app/views/admin/volunteers/edit.html.haml
+++ b/app/views/admin/volunteers/edit.html.haml
@@ -1,0 +1,5 @@
+= content_for :admin_area_title do
+  Updating #{@volunteer.event.name} Volunteer
+.row
+  .col
+    = render 'form'

--- a/app/views/admin/volunteers/index.html.haml
+++ b/app/views/admin/volunteers/index.html.haml
@@ -1,0 +1,15 @@
+= content_for :admin_area_title do
+  Volunteers
+.row
+  .col-12
+    = render "admin/volunteers/filter_button_group"
+.row
+  .col
+    %p.text-muted Inactive volunteers are highlighted in red
+    = render "table"
+.row
+  .col
+    .float-right
+      = link_to "Create New Volunteer",
+        volunteer_path,
+        class: "btn btn-sm btn-success"

--- a/app/views/admin/volunteers/new.html.haml
+++ b/app/views/admin/volunteers/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Volunteer Registrations
+
+= render 'form'
+
+= link_to 'Back', admin_volunteers_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,16 +54,18 @@ Rails.application.routes.draw do
       mount Sidekiq::Web => '/sidekiq'
     end
     get '/' => redirect('admin/main_dashboard')
-    resource :main_dashboard, controller: 'main_dashboard'
     resource :analytics_dashboard, controller: 'analytics_dashboard'
     resources :attachments, only: [:index]
     resources :discount_codes
     resources :events
     resources :file_imports
+    resources :home_page_images
     resources :locations
     resources :mailings
+    resource :main_dashboard, controller: 'main_dashboard'
     resources :participants
     resources :payments
+    resource :profile, controller: "profile", only: [:show, :edit, :update]
     resources :races do
       collection do
         get :archived
@@ -82,8 +84,7 @@ Rails.application.routes.draw do
     resources :series
     resources :sponsors
     resources :team_members
-    resource :profile, controller: "profile", only: [:show, :edit, :update]
     resources :users
-    resources :home_page_images
+    resources :volunteers
   end
 end


### PR DESCRIPTION
Allow admins to manage volunteer registrations from the admin space. Streamlines the volunteer process and eliminates manual work.

-add admin volunteers routes and alphabetize
-add active and inactive volunteer scopes
-add admin volunteers controller
-add full_name volunteer decorator method
-add volunteers link to admin sidebar
-add volunteers link to event dropdown menu
-add volunteers to admin views

[finishes #175443529]