### PR TITLE
update archives race service

### DIFF
--- a/app/services/archives_race.rb
+++ b/app/services/archives_race.rb
@@ -8,7 +8,7 @@ class ArchivesRace
 
   def perform
     ActiveRecord::Base.transaction do
-      race.update(archived_at: Time.current)
+      race.update(archived_at: Time.current, is_active: false)
       update_race_registrations
     end
   end


### PR DESCRIPTION
Updates service to set race is_active boolean to false when archiving. Prevents admin from having to remember to do this manually before archiving a race.

[finishes #176766248]