### PR TITLE
update event sold_out logic

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -41,10 +41,6 @@ class Event < ApplicationRecord
   end
 
   def sold_out?
-    races.each do |race|
-      return false if race.is_full? == false
-    end
-
-    true
+    races.active.upcoming.not_archived.all? { |race| race.is_full? }
   end
 end


### PR DESCRIPTION
Fixes bug with orange event banner to ignore archived races that was causing the view to render as if there were open spots remaining for sold out events.

-refactor event sold_out? method to use ruby all? method
-adds active, upcoming, and not_archived race scopes to event sold_out? method